### PR TITLE
Reworked array merging logic for more flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ the new keys in the file merged on top of the original.
 
 Arrays can be merged in three ways - prepending data, appending data, and completely replacing data.
 
-- To append data to an existing array, ensure that the first element in the new array is `(( merge ))`
-- To prepend the data to an existing array, ensure that the *last* element in the new array is `(( merge ))`
+- To append data to an existing array, ensure that the first element in the new array is `(( append ))`
+- To prepend the data to an existing array, ensure that the first element in the new array is `(( prepend ))`
+- To merge the two arrays together (each index of the new array will be merged into the original, additionals appended),
+  ensure that the first element in the new array is `(( inline ))`
 - To completely replace the array, don't do anything special - just make the new array what you want it to be!
 
 ### Hmm.. How about auto-calculating resource pool sizes, and static IPs?
@@ -85,6 +87,10 @@ top:
   - 2
   - 3
   - 4
+  inline_array_merge:
+  - will be overwritten
+  - this: will
+    be: merged
 ```
 
 And want to merge in this:
@@ -99,11 +105,11 @@ top:
     key2: ~
     key3:
       subkey3:
-      - (( merge ))
+      - (( append ))
       - nested element 3
   array1:
+  - (( prepend ))
   - prepend this
-  - (( merge ))
   array2:
   - over
   - ridden
@@ -112,6 +118,11 @@ top:
   2:
     even: drastically
     to:   from scalars to maps/lists
+  inline_array_merge:
+  - (( inline ))
+  - this has been overwritten
+  - be: overwritten
+    merging: success!
 othertop: you can add new top level keys too
 ```
 
@@ -136,6 +147,11 @@ top:
   - over
   - ridden
   - array
+  inline_array_merge:
+  - this has been overwritten
+  - this: will
+    be: overwritten
+    merge: success!
   map:
     key1: replaced key
     key2: null

--- a/assets/examples/example.yml
+++ b/assets/examples/example.yml
@@ -22,3 +22,7 @@ top:
   - 2
   - 3
   - 4
+  inline_array_merge:
+  - will be overwritten
+  - this: will
+    be: merged

--- a/assets/examples/example2.yml
+++ b/assets/examples/example2.yml
@@ -7,11 +7,11 @@ top:
     key2: ~
     key3:
       subkey3:
-      - (( merge ))
+      - (( append ))
       - nested element 3
   array1:
+  - (( prepend ))
   - prepend this
-  - (( merge ))
   array2:
   - over
   - ridden
@@ -21,3 +21,8 @@ top:
     even: drastically
     to:   from scalars to maps/lists
 othertop: you can add new top level keys too
+  inline_array_merge:
+  - (( inline ))
+  - this has been overwritten
+  - be: overwritten
+    merging: success!

--- a/assets/merge/first.yml
+++ b/assets/merge/first.yml
@@ -1,6 +1,13 @@
 key: value
-array:
+array_append:
 - one
 - two
+array_prepend:
+- four
+- five
+array_inline:
+- name: first_elem
+  val: initial
+- second_elem_is_scalar
 map:
   key: value

--- a/assets/merge/second.yml
+++ b/assets/merge/second.yml
@@ -1,6 +1,14 @@
 key: overridden
-array:
-- (( merge ))
+array_append:
+- (( append ))
 - three
+array_prepend:
+- (( prepend ))
+- three
+array_inline:
+- (( inline ))
+- val: overwritten
+- second_elem was overwritten
+- third elem is appended
 map:
   key2: val2

--- a/main_test.go
+++ b/main_test.go
@@ -62,8 +62,14 @@ func TestMergeAllDocs(t *testing.T) {
 		Convey("Succeeds with valid files + yaml", func() {
 			target := map[interface{}]interface{}{}
 			expect := map[interface{}]interface{}{
-				"key":   "overridden",
-				"array": []interface{}{"one", "two", "three"},
+				"key":           "overridden",
+				"array_append":  []interface{}{"one", "two", "three"},
+				"array_prepend": []interface{}{"three", "four", "five"},
+				"array_inline": []interface{}{
+					map[interface{}]interface{}{"name": "first_elem", "val": "overwritten"},
+					"second_elem was overwritten",
+					"third elem is appended",
+				},
 				"map": map[interface{}]interface{}{
 					"key":  "value",
 					"key2": "val2",
@@ -117,10 +123,19 @@ func TestMain(t *testing.T) {
 			stdout = ""
 			stderr = ""
 			main()
-			So(stdout, ShouldEqual, `array:
+			So(stdout, ShouldEqual, `array_append:
 - one
 - two
 - three
+array_inline:
+- name: first_elem
+  val: overwritten
+- second_elem was overwritten
+- third elem is appended
+array_prepend:
+- three
+- four
+- five
 key: overridden
 map:
   key: value


### PR DESCRIPTION
- (( append ))
- (( prepend ))
- (( inline ))

Verbs all should appear as the first element of the new array that is
acting on a previous array. Append/prepend should be fairly obvious.
Inline will merge elements of the arrays together, index by index,
appending the leftovers.

Fixes #7