### PR TITLE
Added key-based merging for arrays of maps:

### DIFF
--- a/assets/merge/error.yml
+++ b/assets/merge/error.yml
@@ -1,0 +1,3 @@
+array_inline:
+- (( merge ))
+- string

--- a/main.go
+++ b/main.go
@@ -118,7 +118,10 @@ func mergeAllDocs(root map[interface{}]interface{}, paths []string) error {
 			return fmt.Errorf("%s: %s\n", path, err.Error())
 		}
 
-		mergeMap(root, doc, "")
+		err = mergeMap(root, doc, "")
+		if err != nil {
+			return fmt.Errorf("%s: %s\n", path, err.Error())
+		}
 		tmpYaml, _ := yaml.Marshal(root) // we don't care about errors for debugging
 		DEBUG("Current data after processing '%s':\n%s", path, tmpYaml)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -59,6 +59,11 @@ func TestMergeAllDocs(t *testing.T) {
 			err := mergeAllDocs(target, []string{"assets/merge/first.yml", "assets/merge/bad.yml"})
 			So(err.Error(), ShouldStartWith, "assets/merge/bad.yml: Root of YAML document is not a hash/map:")
 		})
+		Convey("Fails with mergeMap error", func() {
+			target := map[interface{}]interface{}{}
+			err := mergeAllDocs(target, []string{"assets/merge/first.yml", "assets/merge/error.yml"})
+			So(err.Error(), ShouldStartWith, "assets/merge/error.yml: $.array_inline.0: new object is a string, not a map - cannot merge using keys")
+		})
 		Convey("Succeeds with valid files + yaml", func() {
 			target := map[interface{}]interface{}{}
 			expect := map[interface{}]interface{}{

--- a/merge.go
+++ b/merge.go
@@ -3,9 +3,10 @@ package main
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 )
 
-func mergeMap(orig map[interface{}]interface{}, n map[interface{}]interface{}, node string) {
+func mergeMap(orig map[interface{}]interface{}, n map[interface{}]interface{}, node string) error {
 	if node == "" {
 		node = "$"
 	}
@@ -14,21 +15,29 @@ func mergeMap(orig map[interface{}]interface{}, n map[interface{}]interface{}, n
 		path := fmt.Sprintf("%s.%v", node, k)
 		_, exists := orig[k]
 		if exists {
-			orig[k] = mergeObj(orig[k], val, path)
+			o, err := mergeObj(orig[k], val, path)
+			if err != nil {
+				return err
+			}
+			orig[k] = o
 		} else {
 			DEBUG("%s: not found upstream, adding it", path)
 			orig[k] = val
 		}
 	}
+	return nil
 }
 
-func mergeObj(orig interface{}, n interface{}, node string) interface{} {
+func mergeObj(orig interface{}, n interface{}, node string) (interface{}, error) {
 	switch t := n.(type) {
 	case map[interface{}]interface{}:
 		switch orig.(type) {
 		case map[interface{}]interface{}:
 			DEBUG("%s: performing map merge", node)
-			mergeMap(orig.(map[interface{}]interface{}), n.(map[interface{}]interface{}), node)
+			err := mergeMap(orig.(map[interface{}]interface{}), n.(map[interface{}]interface{}), node)
+			if err != nil {
+				return nil, err
+			}
 		default:
 			DEBUG("%s: replacing with new data (original was not a map)", node)
 			orig = t
@@ -37,20 +46,33 @@ func mergeObj(orig interface{}, n interface{}, node string) interface{} {
 		switch orig.(type) {
 		case []interface{}:
 			DEBUG("%s: performing array merge", node)
-			orig = mergeArray(orig.([]interface{}), n.([]interface{}), node)
+			a, err := mergeArray(orig.([]interface{}), n.([]interface{}), node)
+			if err != nil {
+				return nil, err
+			}
+			orig = a
 		default:
-			DEBUG("%s: replacing with new data (original was not an array)", node)
-			orig = t
+			if orig == nil {
+				DEBUG("%s: performing array merge (original was nil)", node)
+				a, err := mergeArray([]interface{}{}, n.([]interface{}), node)
+				if err != nil {
+					return nil, err
+				}
+				orig = a
+			} else {
+				DEBUG("%s: replacing with new data (original was not an array)", node)
+				orig = t
+			}
 		}
 
 	default:
 		DEBUG("%s: replacing with new data (new data is neither map nor array)", node)
 		orig = t
 	}
-	return orig
+	return orig, nil
 }
 
-func mergeArray(orig []interface{}, n []interface{}, node string) []interface{} {
+func mergeArray(orig []interface{}, n []interface{}, node string) ([]interface{}, error) {
 	var merged []interface{}
 	if shouldAppendToArray(n) {
 		DEBUG("%s: appending %d new elements to existing array, starting at index %d", node, len(n)-1, len(orig))
@@ -73,24 +95,83 @@ func mergeArray(orig []interface{}, n []interface{}, node string) []interface{} 
 			if i+1 >= len(n) {
 				merged[i] = orig[i]
 			} else {
-				merged[i] = mergeObj(orig[i], n[i+1], fmt.Sprintf("%s.%d", node, i))
+				o, err := mergeObj(orig[i], n[i+1], fmt.Sprintf("%s.%d", node, i))
+				if err != nil {
+					return nil, err
+				}
+				merged[i] = o
 			}
 			last = i
 		}
 
-		last++ // move to next index after finishing the orig slice
+		if len(orig) > 0 {
+			last++ // move to next index after finishing the orig slice - but only if we looped
+		}
 
 		// grab the remainder of n (if any), accounting for the "(( inline ))" element
 		// and append the to the result
 		for i := last; i < len(n)-1; i++ {
 			DEBUG("%s.%d: appending new data to existing array", node, i)
-			merged[i] = n[i+1]
+			o, err := mergeObj(nil, n[i+1], fmt.Sprintf("%s.%d", node, i))
+			if err != nil {
+				return nil, err
+			}
+			merged[i] = o
+		}
+	} else if should, key := shouldKeyMergeArray(n); should {
+		DEBUG("%s: performing key-based array merge, using key '%s'", node, key)
+		merged = make([]interface{}, len(orig), len(orig))
+
+		newArray := n[1:]
+
+		newMap := make(map[interface{}]interface{})
+		for i, o := range newArray {
+			if reflect.TypeOf(o).Kind() != reflect.Map {
+				return nil, fmt.Errorf("%s.%d: new object is a %s, not a map - cannot merge using keys", node, i, reflect.TypeOf(o).Kind().String())
+			}
+			obj := o.(map[interface{}]interface{})
+			if _, ok := obj[key]; !ok {
+				return nil, fmt.Errorf("%s.%d: new object does not contain the key '%s' - cannot merge", node, i, key)
+			}
+
+			newMap[obj[key]] = obj
+		}
+
+		for i, obj := range orig {
+			if reflect.TypeOf(obj).Kind() != reflect.Map {
+				return nil, fmt.Errorf("%s.%d: original object is a %s, not a map - cannot merge using keys", node, i, reflect.TypeOf(obj).Kind().String())
+			}
+			obj := obj.(map[interface{}]interface{})
+			if _, ok := obj[key]; !ok {
+				return nil, fmt.Errorf("%s.%d: original object does not contain the key '%s' - cannot merge", node, i, key)
+			}
+
+			if _, ok := newMap[obj[key]]; ok {
+				o, err := mergeObj(obj, newMap[obj[key]], fmt.Sprintf("%s.%d", node, i))
+				if err != nil {
+					return nil, err
+				}
+				merged[i] = o
+				delete(newMap, obj[key])
+			} else {
+				merged[i] = obj
+			}
+		}
+
+		i := 0
+		for _, obj := range newArray {
+			obj := obj.(map[interface{}]interface{})
+			if _, ok := newMap[obj[key]]; ok {
+				DEBUG("%s.%d: appending new data to merged array", node, i)
+				merged = append(merged, obj)
+				i++
+			}
 		}
 	} else {
 		DEBUG("%s: replacing with new data (no specific array merge behavior requested)", node)
 		merged = n
 	}
-	return merged
+	return merged, nil
 }
 
 func shouldInlineMergeArray(obj []interface{}) bool {
@@ -101,4 +182,23 @@ func shouldAppendToArray(obj []interface{}) bool {
 }
 func shouldPrependToArray(obj []interface{}) bool {
 	return len(obj) >= 1 && reflect.TypeOf(obj[0]).Kind() == reflect.String && obj[0].(string) == "(( prepend ))"
+}
+func shouldKeyMergeArray(obj []interface{}) (bool, string) {
+	key := "name"
+
+	if len(obj) >= 1 && reflect.TypeOf(obj[0]).Kind() == reflect.String {
+		re, err := regexp.Compile("\\Q((\\E\\s*merge(?:\\s+on\\s+(.*?))?\\s*\\Q))\\E")
+		if err != nil {
+			return false, ""
+		}
+
+		if re.MatchString(obj[0].(string)) {
+			keys := re.FindStringSubmatch(obj[0].(string))
+			if keys[1] != "" {
+				key = keys[1]
+			}
+			return true, key
+		}
+	}
+	return false, ""
 }

--- a/merge_test.go
+++ b/merge_test.go
@@ -54,10 +54,106 @@ func TestShouldInlineMergeArray(t *testing.T) {
 		})
 	})
 }
+func TestShouldKeyMergeArrayOfHashes(t *testing.T) {
+	Convey("We should key-based merge arrays of hashes", t, func() {
+		Convey("If the element is a string with the right key-merge token", func() {
+			yes, key := shouldKeyMergeArray([]interface{}{"(( merge ))", "stuff"})
+			So(yes, ShouldBeTrue)
+			So(key, ShouldEqual, "name")
+		})
+		Convey("If the element is a string with the right key-merge token and custom key specified", func() {
+			yes, key := shouldKeyMergeArray([]interface{}{"(( merge on id ))", "stuff"})
+			So(yes, ShouldBeTrue)
+			So(key, ShouldEqual, "id")
+		})
+		Convey("Is whitespace agnostic", func() {
+			Convey("No surrounding whitespace", func() {
+				yes, key := shouldKeyMergeArray([]interface{}{"((merge))"})
+				So(yes, ShouldBeTrue)
+				So(key, ShouldEqual, "name")
+			})
+			Convey("Surrounding tabs", func() {
+				yes, key := shouldKeyMergeArray([]interface{}{"((	merge	))"})
+				So(yes, ShouldBeTrue)
+				So(key, ShouldEqual, "name")
+			})
+			Convey("Multiple surrounding whitespaces", func() {
+				yes, key := shouldKeyMergeArray([]interface{}{"((  merge  ))"})
+				So(yes, ShouldBeTrue)
+				So(key, ShouldEqual, "name")
+			})
+			Convey("Multiple whitespace in key spec", func() {
+				yes, key := shouldKeyMergeArray([]interface{}{"((  merge  on  id  ))"})
+				So(yes, ShouldBeTrue)
+				So(key, ShouldEqual, "id")
+			})
+			Convey("Tabs in key spec", func() {
+				yes, key := shouldKeyMergeArray([]interface{}{"((  merge	on	id  ))"})
+				So(yes, ShouldBeTrue)
+				So(key, ShouldEqual, "id")
+			})
+			Convey("No trailing whitespace in key spec", func() {
+				yes, key := shouldKeyMergeArray([]interface{}{"((  merge	on	id))"})
+				So(yes, ShouldBeTrue)
+				So(key, ShouldEqual, "id")
+			})
+			Convey("No whitespace in key spec", func() {
+				yes, key := shouldKeyMergeArray([]interface{}{"((  mergeonid ))"})
+				So(yes, ShouldBeFalse)
+				So(key, ShouldEqual, "")
+			})
+			Convey("Only leading whitespace in key spec", func() {
+				yes, key := shouldKeyMergeArray([]interface{}{"((  merge onid ))"})
+				So(yes, ShouldBeFalse)
+				So(key, ShouldEqual, "")
+			})
+		})
+		Convey("But not if the element is a string with the wrong token", func() {
+			yes, key := shouldKeyMergeArray([]interface{}{"not a magic token"})
+			So(yes, ShouldBeFalse)
+			So(key, ShouldEqual, "")
+		})
+		Convey("But not if the element is not a string", func() {
+			yes, key := shouldKeyMergeArray([]interface{}{42})
+			So(yes, ShouldBeFalse)
+			So(key, ShouldEqual, "")
+		})
+		Convey("But not if the slice has no elements", func() {
+			yes, key := shouldKeyMergeArray([]interface{}{})
+			So(yes, ShouldBeFalse)
+			So(key, ShouldEqual, "")
+		})
+	})
+}
 
 func TestMergeObj(t *testing.T) {
 	Convey("Passing a map to mergeObj merges as a map", t, func() {
+		Convey("merges as a map under normal conditions", func() {
+			orig := map[interface{}]interface{}{"first": 1, "second": 2}
+			n := map[interface{}]interface{}{"second": 4, "third": 3}
+			expect := map[interface{}]interface{}{"first": 1, "second": 4, "third": 3}
 
+			o, err := mergeObj(orig, n, "node-path")
+			So(o, ShouldResemble, expect)
+			So(err, ShouldBeNil)
+		})
+		Convey("returns an error when mergeMap throws an error", func() {
+			origMap := map[interface{}]interface{}{
+				"array": []interface{}{
+					"string",
+				},
+			}
+			newMap := map[interface{}]interface{}{
+				"array": []interface{}{
+					"(( merge on name ))",
+					"string",
+				},
+			}
+			o, err := mergeObj(origMap, newMap, "node-path")
+			So(o, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "node-path.array.0: new object is a string, not a map - cannot merge using keys")
+		})
 	})
 	Convey("Passing a slice to mergeObj", t, func() {
 		Convey("without magical merge token replaces entire array", func() {
@@ -65,51 +161,102 @@ func TestMergeObj(t *testing.T) {
 			array := []interface{}{"my", "new", "array"}
 			expect := []interface{}{"my", "new", "array"}
 
-			So(mergeObj(orig, array, "node-path"), ShouldResemble, expect)
+			o, err := mergeObj(orig, array, "node-path")
+			So(o, ShouldResemble, expect)
+			So(err, ShouldBeNil)
+		})
+		Convey("When passed a slice, but original item is nil", func() {
+			val := []interface{}{"(( append ))", "two"}
+			expect := []interface{}{"two"}
+
+			o, err := mergeObj(nil, val, "node-path")
+			So(o, ShouldResemble, expect)
+			So(err, ShouldBeNil)
+		})
+		Convey("Returns an error when mergeArray throws an error, when merging array to array", func() {
+			orig := []interface{}{
+				"first",
+			}
+			array := []interface{}{
+				"(( merge on name ))",
+				"second",
+			}
+
+			o, err := mergeObj(orig, array, "node-path")
+			So(o, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "node-path.0: new object is a string, not a map - cannot merge using keys")
+		})
+		Convey("Returns an error when mergeArray throws an error, when merging nil to array", func() {
+			array := []interface{}{
+				"(( merge on name ))",
+				"second",
+			}
+
+			o, err := mergeObj(nil, array, "node-path")
+			So(o, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "node-path.0: new object is a string, not a map - cannot merge using keys")
 		})
 	})
 	Convey("mergeObj merges in place", t, func() {
 		Convey("When passed a string", func() {
 			orig := 42
 			val := "asdf"
-			So(mergeObj(orig, val, "node-path"), ShouldEqual, "asdf")
+
+			o, err := mergeObj(orig, val, "node-path")
+			So(o, ShouldEqual, "asdf")
+			So(err, ShouldBeNil)
 		})
 		Convey("When passed an int", func() {
 			orig := "fdsa"
 			val := 10
-			So(mergeObj(orig, val, "node-path"), ShouldEqual, 10)
+
+			o, err := mergeObj(orig, val, "node-path")
+			So(o, ShouldEqual, 10)
+			So(err, ShouldBeNil)
 		})
 		Convey("When passed an float64", func() {
 			orig := "fdsa"
 			val := 10.4
-			So(mergeObj(orig, val, "node-path"), ShouldEqual, 10.4)
+
+			o, err := mergeObj(orig, val, "node-path")
+			So(o, ShouldEqual, 10.4)
+			So(err, ShouldBeNil)
 		})
 		Convey("When passed nil", func() {
 			orig := "fdsa"
 			val := interface{}(nil)
-			So(mergeObj(orig, val, "node-path"), ShouldBeNil)
+
+			o, err := mergeObj(orig, val, "node-path")
+			So(o, ShouldBeNil)
+			So(err, ShouldBeNil)
 		})
 		Convey("When passed a map, but original item is a scalar", func() {
 			orig := "value"
 			val := map[interface{}]interface{}{"key": "value"}
 			expect := map[interface{}]interface{}{"key": "value"}
-			So(mergeObj(orig, val, "node-path"), ShouldResemble, expect)
+
+			o, err := mergeObj(orig, val, "node-path")
+			So(o, ShouldResemble, expect)
+			So(err, ShouldBeNil)
 		})
 		Convey("When passed a map, but original item is nil", func() {
 			val := map[interface{}]interface{}{"key": "value"}
 			expect := map[interface{}]interface{}{"key": "value"}
-			So(mergeObj(nil, val, "node-path"), ShouldResemble, expect)
+
+			o, err := mergeObj(nil, val, "node-path")
+			So(o, ShouldResemble, expect)
+			So(err, ShouldBeNil)
 		})
 		Convey("When passed a slice, but original item is a scalar", func() {
 			orig := "value"
 			val := []interface{}{"one", "two"}
 			expect := []interface{}{"one", "two"}
-			So(mergeObj(orig, val, "node-path"), ShouldResemble, expect)
-		})
-		Convey("When passed a slice, but original item is nil", func() {
-			val := []interface{}{"one", "two"}
-			expect := []interface{}{"one", "two"}
-			So(mergeObj(nil, val, "node-path"), ShouldResemble, expect)
+
+			o, err := mergeObj(orig, val, "node-path")
+			So(o, ShouldResemble, expect)
+			So(err, ShouldBeNil)
 		})
 	})
 }
@@ -120,8 +267,25 @@ func TestMergeMap(t *testing.T) {
 		newMap := map[interface{}]interface{}{"k3": "v3", "k2": "v2.new"}
 		expectMap := map[interface{}]interface{}{"k2": "v2.new", "k3": "v3", "k1": "v1"}
 
-		mergeMap(origMap, newMap, "node-path")
+		err := mergeMap(origMap, newMap, "node-path")
 		So(origMap, ShouldResemble, expectMap)
+		So(err, ShouldBeNil)
+	})
+	Convey("mergeMap re-throws an error if it finds one while merging data", t, func() {
+		origMap := map[interface{}]interface{}{
+			"array": []interface{}{
+				"string",
+			},
+		}
+		newMap := map[interface{}]interface{}{
+			"array": []interface{}{
+				"(( merge on name ))",
+				"string",
+			},
+		}
+		err := mergeMap(origMap, newMap, "node-path")
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldEqual, "node-path.array.0: new object is a string, not a map - cannot merge using keys")
 	})
 }
 
@@ -132,14 +296,18 @@ func TestMergeArray(t *testing.T) {
 			array := []interface{}{"(( prepend ))", "zeroth"}
 			expect := []interface{}{"zeroth", "first", "second"}
 
-			So(mergeArray(orig, array, "node-path"), ShouldResemble, expect)
+			a, err := mergeArray(orig, array, "node-path")
+			So(a, ShouldResemble, expect)
+			So(err, ShouldBeNil)
 		})
 		Convey("with initial element '(( append ))' appends new data", func() {
 			orig := []interface{}{"first", "second"}
 			array := []interface{}{"(( append ))", "third"}
 			expect := []interface{}{"first", "second", "third"}
 
-			So(mergeArray(orig, array, "node-path"), ShouldResemble, expect)
+			a, err := mergeArray(orig, array, "node-path")
+			So(a, ShouldResemble, expect)
+			So(err, ShouldBeNil)
 		})
 		Convey("with initial element '(( inline ))'", func() {
 			Convey("and len(orig) == len(new)", func() {
@@ -170,7 +338,9 @@ func TestMergeArray(t *testing.T) {
 					},
 					"overwritten_last",
 				}
-				So(mergeArray(orig, array, "node-path"), ShouldResemble, expect)
+				a, err := mergeArray(orig, array, "node-path")
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
 			})
 			Convey("and len(orig) > len(new)", func() {
 				orig := []interface{}{
@@ -199,7 +369,9 @@ func TestMergeArray(t *testing.T) {
 					},
 					"orig_last",
 				}
-				So(mergeArray(orig, array, "node-path"), ShouldResemble, expect)
+				a, err := mergeArray(orig, array, "node-path")
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
 			})
 			Convey("and len(orig < len(new)", func() {
 				orig := []interface{}{
@@ -223,11 +395,210 @@ func TestMergeArray(t *testing.T) {
 					},
 					"overwritten_last",
 				}
-				So(mergeArray(orig, array, "node-path"), ShouldResemble, expect)
+				a, err := mergeArray(orig, array, "node-path")
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
 			})
 			Convey("and empty orig slice", func() {
+				orig := []interface{}{}
+				array := []interface{}{
+					"(( inline ))",
+					"overwritten_first",
+					[]interface{}{"(( append ))", "subthird"},
+					map[interface{}]interface{}{
+						"val": "overwritten",
+					},
+					"overwritten_last",
+				}
+				expect := []interface{}{
+					"overwritten_first",
+					[]interface{}{"subthird"},
+					map[interface{}]interface{}{
+						"val": "overwritten",
+					},
+					"overwritten_last",
+				}
+				a, err := mergeArray(orig, array, "node-path")
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
 			})
-			Convey("and empty new slice", func() {
+			Convey("returns error when mergObj returns error (merged data)", func() {
+				orig := []interface{}{
+					[]interface{}{
+						"string",
+					},
+				}
+				array := []interface{}{
+					"(( inline ))",
+					[]interface{}{
+						"(( merge ))",
+						"string",
+					},
+				}
+				a, err := mergeArray(orig, array, "node-path")
+				So(a, ShouldBeNil)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "node-path.0.0: new object is a string, not a map - cannot merge using keys")
+			})
+			Convey("returns error when mergObj returns error (appended data)", func() {
+				orig := []interface{}{}
+				array := []interface{}{
+					"(( inline ))",
+					[]interface{}{
+						"(( merge ))",
+						"string",
+					},
+				}
+				a, err := mergeArray(orig, array, "node-path")
+				So(a, ShouldBeNil)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "node-path.0.0: new object is a string, not a map - cannot merge using keys")
+			})
+		})
+		Convey("with initial element '(( merge ))'", func() {
+			Convey("merges and defaults to 'name' for a key, if not specified", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{"name": "job1", "id": "1", "org": "org1"},
+					map[interface{}]interface{}{"name": "job3", "id": "3", "org": "org3"},
+					map[interface{}]interface{}{"name": "job2", "id": "2", "org": "org2"},
+				}
+				array := []interface{}{
+					"(( merge ))",
+					map[interface{}]interface{}{"name": "job2", "org": "myorg2"},
+					map[interface{}]interface{}{"name": "job4", "org": "myorg4"},
+					map[interface{}]interface{}{"name": "job1", "org": "myorg1"},
+				}
+				expect := []interface{}{
+					map[interface{}]interface{}{"name": "job1", "id": "1", "org": "myorg1"},
+					map[interface{}]interface{}{"name": "job3", "id": "3", "org": "org3"},
+					map[interface{}]interface{}{"name": "job2", "id": "2", "org": "myorg2"},
+					map[interface{}]interface{}{"name": "job4", "org": "myorg4"},
+				}
+
+				a, err := mergeArray(orig, array, "node-path")
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
+			})
+			Convey("allows custom key merging to be specified", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{"id": "1", "org": "org1"},
+					map[interface{}]interface{}{"id": "3", "org": "org3"},
+					map[interface{}]interface{}{"id": "2", "org": "org2"},
+				}
+				array := []interface{}{
+					"(( merge on id ))",
+					map[interface{}]interface{}{"id": "2", "org": "myorg2"},
+					map[interface{}]interface{}{"id": "4", "org": "myorg4"},
+					map[interface{}]interface{}{"id": "1", "org": "myorg1"},
+				}
+				expect := []interface{}{
+					map[interface{}]interface{}{"id": "1", "org": "myorg1"},
+					map[interface{}]interface{}{"id": "3", "org": "org3"},
+					map[interface{}]interface{}{"id": "2", "org": "myorg2"},
+					map[interface{}]interface{}{"id": "4", "org": "myorg4"},
+				}
+
+				a, err := mergeArray(orig, array, "node-path")
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
+			})
+			Convey("But not if any of the original array elements are not maps", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{"id": "1", "org": "org1"},
+					map[interface{}]interface{}{"id": "3", "org": "org3"},
+					map[interface{}]interface{}{"id": "2", "org": "org2"},
+					"this will make it fail",
+				}
+				array := []interface{}{
+					"(( merge on id ))",
+					map[interface{}]interface{}{"id": "2", "org": "myorg2"},
+					map[interface{}]interface{}{"id": "4", "org": "myorg4"},
+					map[interface{}]interface{}{"id": "1", "org": "myorg1"},
+				}
+
+				a, err := mergeArray(orig, array, "node-path")
+				So(a, ShouldBeNil)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "node-path.3: original object is a string, not a map - cannot merge using keys")
+			})
+			Convey("But not if any of the new array elements are not maps", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{"id": "1", "org": "org1"},
+					map[interface{}]interface{}{"id": "3", "org": "org3"},
+					map[interface{}]interface{}{"id": "2", "org": "org2"},
+				}
+				array := []interface{}{
+					"(( merge on id ))",
+					map[interface{}]interface{}{"id": "2", "org": "myorg2"},
+					map[interface{}]interface{}{"id": "4", "org": "myorg4"},
+					map[interface{}]interface{}{"id": "1", "org": "myorg1"},
+					"this will make it fail",
+				}
+
+				a, err := mergeArray(orig, array, "node-path")
+				So(a, ShouldBeNil)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "node-path.3: new object is a string, not a map - cannot merge using keys")
+			})
+			Convey("But not if any of the elements of the original array don't have the key requested", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{"id": "1", "org": "org1"},
+					map[interface{}]interface{}{"id": "3", "org": "org3"},
+					map[interface{}]interface{}{"name": "2", "org": "org2"},
+				}
+				array := []interface{}{
+					"(( merge on id ))",
+					map[interface{}]interface{}{"id": "2", "org": "myorg2"},
+					map[interface{}]interface{}{"id": "4", "org": "myorg4"},
+					map[interface{}]interface{}{"id": "1", "org": "myorg1"},
+				}
+
+				a, err := mergeArray(orig, array, "node-path")
+				So(a, ShouldBeNil)
+				So(err, ShouldNotBeNil)
+
+			})
+			Convey("But not if any of the elements of the new array don't have the key requested", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{"id": "1", "org": "org1"},
+					map[interface{}]interface{}{"id": "3", "org": "org3"},
+					map[interface{}]interface{}{"id": "2", "org": "org2"},
+				}
+				array := []interface{}{
+					"(( merge on id ))",
+					map[interface{}]interface{}{"id": "2", "org": "myorg2"},
+					map[interface{}]interface{}{"id": "4", "org": "myorg4"},
+					map[interface{}]interface{}{"name": "1", "org": "myorg1"},
+				}
+
+				a, err := mergeArray(orig, array, "node-path")
+				So(a, ShouldBeNil)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "node-path.2: new object does not contain the key 'id' - cannot merge")
+			})
+			Convey("Returns an error if mergeObj() returns an error", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{
+						"name": "first",
+						"val": []interface{}{
+							"string",
+						},
+					},
+				}
+				array := []interface{}{
+					"(( merge ))",
+					map[interface{}]interface{}{
+						"name": "first",
+						"val": []interface{}{
+							"(( merge ))",
+							"string",
+						},
+					},
+				}
+				a, err := mergeArray(orig, array, "node-path")
+				So(a, ShouldBeNil)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "node-path.0.val.0: new object is a string, not a map - cannot merge using keys")
 			})
 		})
 		Convey("with map elements replaces entire array", func() {
@@ -238,14 +609,18 @@ func TestMergeArray(t *testing.T) {
 			array := []interface{}{newMapSlice}
 			expect := []interface{}{expectMapSlice}
 
-			So(mergeObj(orig, array, "node-path"), ShouldResemble, expect)
+			o, err := mergeObj(orig, array, "node-path")
+			So(o, ShouldResemble, expect)
+			So(err, ShouldBeNil)
 		})
 		Convey("without magical merge token replaces entire array", func() {
 			orig := []interface{}{"first", "second"}
 			array := []interface{}{"my", "new", "array"}
 			expect := []interface{}{"my", "new", "array"}
 
-			So(mergeObj(orig, array, "node-path"), ShouldResemble, expect)
+			o, err := mergeObj(orig, array, "node-path")
+			So(o, ShouldResemble, expect)
+			So(err, ShouldBeNil)
 		})
 	})
 }


### PR DESCRIPTION
Using the "(( merge ))" token for an array merge
will check to see if the source and destination elements
of the array are maps, containing the "name" key. If so,
it will merge elements together (regardless of order),
identifying matches based on their "name".

Using "(( merge on <mykey> ))" will behave the same way,
but use the key represented by <mykey> to determine object
matching.

Existing elements are kept in order, and updated in place (if
there was a matching object in the new array). New elements that
do not match any existing elements are appended to the end of the
array (in the order specified in the new array).