### PR TITLE
Added --concourse flag to handle merging of cocnourse ymls

### DIFF
--- a/assets/concourse/first.yml
+++ b/assets/concourse/first.yml
@@ -1,0 +1,3 @@
+jobs:
+- name: thing1
+  curlies: {{my-variable_123}}

--- a/assets/concourse/second.yml
+++ b/assets/concourse/second.yml
@@ -1,0 +1,4 @@
+jobs:
+- (( append ))
+- name: thing2
+  curlies: {{more}}


### PR DESCRIPTION
Concourse contains a `{{stuff}}` construct in their yml files
for merging in variables from other files. This confuses and infuriates
the goyaml parser. So, this flag handles automated quoting + dequoting
of that text, to make the concourse spruce merging seemless.

Yay!