### PR TITLE
Support for (( prune ))

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,21 @@ Arrays can be merged in three ways - prepending data, appending data, and comple
 
   ```yml
   - (( merge on <key> ))
-  ````
+  ```
 
 <br> The first merges using `name` as the key to determine
   like objects in the array elements. The second is used to customize which key to use. See [Merging Arrays of Maps](#mapmerge)
   for an example.
+
 - To completely replace the array, don't do anything special - just make the new array what you want it to be!
+
+### Cleaning Up After Yourself
+
+- To prune a map key from the final output<br>
+
+  ```yml
+  useless: (( prune ))
+  ```
 
 ### Hmm.. How about auto-calculating resource pool sizes, and static IPs?
 
@@ -201,7 +210,7 @@ top:
   orig_key: this is replaced
 ```
 
-###Map replacements
+### Map Replacements
 
 One of [spiff's](https://github.com/cloudfoundry-incubator/spiff) quirks was that it quite easily allowed you to completely replace an
 entire map, with new data (rather than merging by default). That result is still
@@ -249,6 +258,47 @@ untouched:
 ```
 
 *NOTE:* due to map key randomizations, the actual order of the above output will vary.
+
+### Key Removal
+
+How about deleting keys outright?
+
+```yml
+---
+# original.yml
+meta:
+  thing: &thing
+    foo: 1
+    bar: 2
+
+things:
+  - <<: *thing
+    name: first-thing
+  - <<: *thing
+    name: second-thing
+```
+
+The `meta` key is only useful for holding the `*thing` referent,
+so we'd really rather not see it in the final output:
+
+```yml
+---
+# prune.yml
+meta: (( prune ))
+```
+
+```yml
+$ spruce merge original.yml prune.yml
+things:
+  - name: first-thing
+    foo: 1
+    bar: 2
+  - name: second-thing
+    foo: 1
+    bar: 2
+
+```
+
 
 ###<a name="mapmerge"></a>Merging Arrays of Maps
 

--- a/assets/prune/first.yml
+++ b/assets/prune/first.yml
@@ -1,0 +1,8 @@
+retained: yea
+pruned: still here for some reason
+level2:
+  retained: yea
+  pruned: still here for some reason
+  level3:
+    retained: yea
+    pruned: still here for some reason

--- a/assets/prune/second.yml
+++ b/assets/prune/second.yml
@@ -1,0 +1,5 @@
+pruned: (( prune ))
+level2:
+  pruned: ((prune))
+  level3:
+    pruned: ((		prune   ))

--- a/main_test.go
+++ b/main_test.go
@@ -204,6 +204,22 @@ map:
 `)
 			So(stderr, ShouldEqual, "")
 		})
+
+		Convey("Should handle pruning", func() {
+			os.Args = []string{"spruce", "merge", "assets/prune/first.yml", "assets/prune/second.yml"}
+			stdout = ""
+			stderr = ""
+			main()
+			So(stdout, ShouldEqual, `level2:
+  level3:
+    retained: yea
+  retained: yea
+retained: yea
+
+`)
+
+			So(stderr, ShouldEqual, "")
+		})
 	})
 }
 

--- a/merge.go
+++ b/merge.go
@@ -15,6 +15,14 @@ func mergeMap(orig map[interface{}]interface{}, n map[interface{}]interface{}, n
 		path := fmt.Sprintf("%s.%v", node, k)
 		_, exists := orig[k]
 		if exists {
+			// check the value of the object to see if it is '(( prune ))'
+			if reflect.TypeOf(val).Kind() == reflect.String {
+				re := regexp.MustCompile(`\Q((\E\s*prune\s*\Q))\E`)
+				if re.MatchString(val.(string)) {
+					delete(orig, k)
+					continue
+				}
+			}
 			o, err := mergeObj(orig[k], val, path)
 			if err != nil {
 				return err


### PR DESCRIPTION
Give a hoot! Don't pollute!

Introduces a (( prune )) option for removing keys from the resultant YML.  I debated whether to call it (( delete )), but since spruce is so nature-y, I went with prune.