### PR TITLE
Added support for referencing multiple things at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ pen:
   color: (( grab data.color ))
 ```
 
+You can even reference multiple values at once, getting back an array of their data,
+for things like getting all IPs of multi-AZ jobs in a BOSH manifest, just do it like so:
+
+```(( grab jobs.myJob_z1.networks.myNet1.static_ips jobs.myJob_z2.networks.myNet2.static_ips ))```
+
 ###Hmm.. How about auto-calculating static IPs for a BOSH manifest?
 
 `spruce` supports that too! Just use the same `(( static_ips(x, y, z) ))` syntax

--- a/assets/dereference/multi-value.yml
+++ b/assets/dereference/multi-value.yml
@@ -1,0 +1,26 @@
+jobs:
+- name: api_z1
+  instances: 1
+  networks:
+  - name: net1
+    static_ips: (( static_ips(1, 2, 3) ))
+- name: api_z2
+  instances: 1
+  networks:
+  - name: net2
+    static_ips: (( static_ips(1, 2, 3) ))
+
+networks:
+- name: net1
+  subnets:
+  - cloud_properties: random
+    static:
+    - 192.168.1.2 - 192.168.1.30
+- name: net2
+  subnets:
+  - cloud_properties: random
+    static:
+    - 192.168.2.2 - 192.168.2.30
+
+properties:
+  api_servers: (( grab jobs.api_z1.networks.net1.static_ips jobs.api_z2.networks.net2.static_ips ))

--- a/dereferencer.go
+++ b/dereferencer.go
@@ -33,25 +33,24 @@ func (d DeReferencer) PostProcess(o interface{}, node string) (interface{}, stri
 					}
 					DEBUG("%s: setting to %#v", node, val)
 					return val, "replace", nil
-				} else {
-					val := []interface{}{}
-					for _, target := range targets {
-						DEBUG("%s: resolving from %s", node, target)
-						v, err := resolveNode(target, d.root)
-						if err != nil {
-							return nil, "error", fmt.Errorf("%s: Unable to resolve `%s`: `%s", node, target, err.Error())
-						}
-						if reflect.TypeOf(v).Kind() == reflect.Slice {
-							for i := 0; i < reflect.ValueOf(v).Len(); i++ {
-								val = append(val, reflect.ValueOf(v).Index(i).Interface())
-							}
-						} else {
-							val = append(val, v)
-						}
-					}
-					DEBUG("%s: setting to %#v", node, val)
-					return val, "replace", nil
 				}
+				val := []interface{}{}
+				for _, target := range targets {
+					DEBUG("%s: resolving from %s", node, target)
+					v, err := resolveNode(target, d.root)
+					if err != nil {
+						return nil, "error", fmt.Errorf("%s: Unable to resolve `%s`: `%s", node, target, err.Error())
+					}
+					if reflect.TypeOf(v).Kind() == reflect.Slice {
+						for i := 0; i < reflect.ValueOf(v).Len(); i++ {
+							val = append(val, reflect.ValueOf(v).Index(i).Interface())
+						}
+					} else {
+						val = append(val, v)
+					}
+				}
+				DEBUG("%s: setting to %#v", node, val)
+				return val, "replace", nil
 			}
 		}
 	}

--- a/dereferencer.go
+++ b/dereferencer.go
@@ -19,18 +19,39 @@ func (d DeReferencer) Action() string {
 // PostProcess - resolves a value by seeing if it matches (( grab me.data )) and retrieves me.data's value
 func (d DeReferencer) PostProcess(o interface{}, node string) (interface{}, string, error) {
 	if reflect.TypeOf(o).Kind() == reflect.String {
-		re := regexp.MustCompile("^\\Q((\\E\\s*grab\\s+(\\S+?)\\s*\\Q))\\E$")
+		re := regexp.MustCompile("^\\Q((\\E\\s*grab\\s+(.+?)\\s*\\Q))\\E$")
 		if re.MatchString(o.(string)) {
 			keys := re.FindStringSubmatch(o.(string))
 			if keys[1] != "" {
-				target := keys[1]
-				DEBUG("%s: resolving from %s", node, target)
-				val, err := resolveNode(target, d.root)
-				if err != nil {
-					return nil, "error", fmt.Errorf("%s: Unable to resolve `%s`: `%s", node, target, err.Error())
+				wsSquasher := regexp.MustCompile("\\s+")
+				targets := wsSquasher.Split(keys[1], -1)
+				if len(targets) <= 1 {
+					DEBUG("%s: resolving from %s", node, targets[0])
+					val, err := resolveNode(targets[0], d.root)
+					if err != nil {
+						return nil, "error", fmt.Errorf("%s: Unable to resolve `%s`: `%s", node, targets[0], err.Error())
+					}
+					DEBUG("%s: setting to %#v", node, val)
+					return val, "replace", nil
+				} else {
+					val := []interface{}{}
+					for _, target := range targets {
+						DEBUG("%s: resolving from %s", node, target)
+						v, err := resolveNode(target, d.root)
+						if err != nil {
+							return nil, "error", fmt.Errorf("%s: Unable to resolve `%s`: `%s", node, target, err.Error())
+						}
+						if reflect.TypeOf(v).Kind() == reflect.Slice {
+							for i := 0; i < reflect.ValueOf(v).Len(); i++ {
+								val = append(val, reflect.ValueOf(v).Index(i).Interface())
+							}
+						} else {
+							val = append(val, v)
+						}
+					}
+					DEBUG("%s: setting to %#v", node, val)
+					return val, "replace", nil
 				}
-				DEBUG("%s: setting to %#v", node, val)
-				return val, "replace", nil
 			}
 		}
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -231,6 +231,51 @@ properties:
 			So(stderr, ShouldEndWith, "hit max recursion depth. You seem to have a self-referencing dataset")
 			So(rc, ShouldEqual, 2)
 		})
+		Convey("Dereferencing multiple values should behave as desired", func() {
+			os.Args = []string{"spruce", "merge", "assets/dereference/multi-value.yml"}
+			stdout = ""
+			stderr = ""
+			main()
+			So(stdout, ShouldEqual, `jobs:
+- instances: 1
+  name: api_z1
+  networks:
+  - name: net1
+    static_ips:
+    - 192.168.1.2
+    - 192.168.1.3
+    - 192.168.1.4
+- instances: 1
+  name: api_z2
+  networks:
+  - name: net2
+    static_ips:
+    - 192.168.2.2
+    - 192.168.2.3
+    - 192.168.2.4
+networks:
+- name: net1
+  subnets:
+  - cloud_properties: random
+    static:
+    - 192.168.1.2 - 192.168.1.30
+- name: net2
+  subnets:
+  - cloud_properties: random
+    static:
+    - 192.168.2.2 - 192.168.2.30
+properties:
+  api_servers:
+  - 192.168.1.2
+  - 192.168.1.3
+  - 192.168.1.4
+  - 192.168.2.2
+  - 192.168.2.3
+  - 192.168.2.4
+
+`)
+			So(stderr, ShouldEqual, "")
+		})
 		Convey("Should output error on bad de-reference", func() {
 			os.Args = []string{"spruce", "merge", "assets/dereference/bad.yml"}
 			stdout = ""
@@ -255,7 +300,7 @@ properties:
 			stdout = ""
 			stderr = ""
 			main()
-			So(stderr, ShouldEqual, "$.jobs.[0].networks.[0].static_ips: `$.networks` could not be found in the YAML datastructure")
+			So(stderr, ShouldEqual, "$.jobs.api_z1.networks.net1.static_ips: `$.networks` could not be found in the YAML datastructure")
 			So(stdout, ShouldEqual, "")
 		})
 		Convey("static_ips() get resolved, and are resolved prior to dereferencing", func() {

--- a/post_process.go
+++ b/post_process.go
@@ -64,6 +64,11 @@ func walkTree(root interface{}, p PostProcessor, node string) error {
 	case []interface{}:
 		for i, e := range root.([]interface{}) {
 			path := fmt.Sprintf("%s.[%d]", node, i)
+			if eMap, ok := e.(map[interface{}]interface{}); ok {
+				if name, ok := eMap["name"]; ok {
+					path = fmt.Sprintf("%s.%s", node, name)
+				}
+			}
 			val, action, err := p.PostProcess(e, path)
 			if err != nil {
 				return err


### PR DESCRIPTION
You can reference multiple values in the same `grab`
call using whitespace-separation:

(( grab my.value.one my.value.two ))

For #1