### PR TITLE
Fixed two bugs:

### DIFF
--- a/assets/dereference/multi-value.yml
+++ b/assets/dereference/multi-value.yml
@@ -3,12 +3,12 @@ jobs:
   instances: 1
   networks:
   - name: net1
-    static_ips: (( static_ips(1, 2, 3) ))
+    static_ips: (( static_ips(0, 1, 2) ))
 - name: api_z2
   instances: 1
   networks:
   - name: net2
-    static_ips: (( static_ips(1, 2, 3) ))
+    static_ips: (( static_ips(0, 1, 2) ))
 
 networks:
 - name: net1
@@ -24,3 +24,4 @@ networks:
 
 properties:
   api_servers: (( grab jobs.api_z1.networks.net1.static_ips jobs.api_z2.networks.net2.static_ips ))
+  api_server_primary: (( grab jobs.api_z1.networks.net1.static_ips.[0] ))

--- a/assets/static_ips/jobs.yml
+++ b/assets/static_ips/jobs.yml
@@ -3,4 +3,4 @@ jobs:
   instances: 3
   networks:
   - name: net1
-    static_ips: (( static_ips(1, 2, 3) ))
+    static_ips: (( static_ips(0, 1, 2) ))

--- a/dereferencer.go
+++ b/dereferencer.go
@@ -11,11 +11,6 @@ type DeReferencer struct {
 	root map[interface{}]interface{}
 }
 
-// Action returns the Action string for the Dereferencer
-func (d DeReferencer) Action() string {
-	return "dereference"
-}
-
 // PostProcess - resolves a value by seeing if it matches (( grab me.data )) and retrieves me.data's value
 func (d DeReferencer) PostProcess(o interface{}, node string) (interface{}, string, error) {
 	if reflect.TypeOf(o).Kind() == reflect.String {
@@ -26,7 +21,7 @@ func (d DeReferencer) PostProcess(o interface{}, node string) (interface{}, stri
 				wsSquasher := regexp.MustCompile("\\s+")
 				targets := wsSquasher.Split(keys[1], -1)
 				if len(targets) <= 1 {
-					DEBUG("%s: resolving from %s", node, targets[0])
+					DEBUG("%s: dereferencing value '%s'", node, targets[0])
 					val, err := resolveNode(targets[0], d.root)
 					if err != nil {
 						return nil, "error", fmt.Errorf("%s: Unable to resolve `%s`: `%s", node, targets[0], err.Error())
@@ -36,7 +31,7 @@ func (d DeReferencer) PostProcess(o interface{}, node string) (interface{}, stri
 				}
 				val := []interface{}{}
 				for _, target := range targets {
-					DEBUG("%s: resolving from %s", node, target)
+					DEBUG("%s: dereferencing value '%s'", node, target)
 					v, err := resolveNode(target, d.root)
 					if err != nil {
 						return nil, "error", fmt.Errorf("%s: Unable to resolve `%s`: `%s", node, target, err.Error())

--- a/dereferencer_test.go
+++ b/dereferencer_test.go
@@ -5,13 +5,6 @@ import (
 	"testing"
 )
 
-func TestDeReferencerAction(t *testing.T) {
-	Convey("dereferencer.Action() returns correct string", t, func() {
-		deref := DeReferencer{root: map[interface{}]interface{}{}}
-		So(deref.Action(), ShouldEqual, "dereference")
-	})
-}
-
 func TestDeReferencerPostProcess(t *testing.T) {
 	Convey("dereferencer.PostProces()", t, func() {
 		deref := DeReferencer{root: map[interface{}]interface{}{

--- a/main_test.go
+++ b/main_test.go
@@ -265,6 +265,7 @@ networks:
     static:
     - 192.168.2.2 - 192.168.2.30
 properties:
+  api_server_primary: 192.168.1.2
   api_servers:
   - 192.168.1.2
   - 192.168.1.3

--- a/post_process.go
+++ b/post_process.go
@@ -8,7 +8,6 @@ import (
 // PostProcessor interface to allow for flexible post-processing of the tree
 type PostProcessor interface {
 	PostProcess(interface{}, string) (interface{}, string, error)
-	Action() string
 }
 
 // Current recursion depth
@@ -55,7 +54,6 @@ func walkTree(root interface{}, p PostProcessor, node string) error {
 				root.(map[interface{}]interface{})[k] = replacement
 			}
 
-			DEBUG("%s: scanning for values to %s", path, p.Action())
 			err = walkTree(root.(map[interface{}]interface{})[k], p, path)
 			if err != nil {
 				return err
@@ -83,7 +81,6 @@ func walkTree(root interface{}, p PostProcessor, node string) error {
 				}
 				root.([]interface{})[i] = replacement
 			}
-			DEBUG("%s: scanning for values needing to be resolved", path)
 			err = walkTree(root.([]interface{})[i], p, path)
 			if err != nil {
 				return err

--- a/post_process_test.go
+++ b/post_process_test.go
@@ -11,9 +11,6 @@ type MockPostProcessor struct {
 	value  interface{}
 }
 
-func (p MockPostProcessor) Action() string {
-	return p.action
-}
 func (p MockPostProcessor) PostProcess(i interface{}, node string) (interface{}, string, error) {
 	if _, ok := i.(string); ok && i.(string) == "(( mock ))" {
 		if p.action == "error" {

--- a/resolve.go
+++ b/resolve.go
@@ -16,7 +16,7 @@ func resolveNode(target string, lookup map[interface{}]interface{}) (interface{}
 
 func resolveNodeObj(keys []string, lookup interface{}) (interface{}, error) {
 	toFind, keys := keys[0], keys[1:]
-	DEBUG("   RESOLVE: searching for %s", toFind)
+	DEBUG("   RESOLVE: searching for %q", toFind)
 	switch lookup.(type) {
 	case map[interface{}]interface{}:
 		m := lookup.(map[interface{}]interface{})
@@ -46,6 +46,8 @@ func resolveNodeObj(keys []string, lookup interface{}) (interface{}, error) {
 				}
 			}
 		}
+	default:
+		return nil, fmt.Errorf("Tried to reference unspported value type '%s'. This is a post-processing bug", reflect.TypeOf(lookup).String())
 	}
 	return nil, fmt.Errorf("%s` could not be found in the YAML datastructure", toFind)
 }


### PR DESCRIPTION
1. static_ips() was returning []string's instead of []interface{}'s, causing
   resolveNode to have issues trying to find them when specific IPs are being
   dereferenced.

2. static_ips() was expecing 1-based offsets, but spiff templates actually use 0-based,
   so I made spruce 0-based as well, since my understanding of spiff was wrong.