### PR TITLE
Implement grab_if_exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,13 +120,20 @@ for things like getting all IPs of multi-AZ jobs in a BOSH manifest, just do it 
 
 ```(( grab jobs.myJob_z1.networks.myNet1.static_ips jobs.myJob_z2.networks.myNet2.static_ips ))```
 
+If one or more of the references cannot be resolved, your `grab` will fail. Sometimes, rather
+than failing, you want unresolvable references to be replaced with a null value instead. You can
+totally do that!
+
+```(( grab_if_exists jobs.myJob_z1.networks.myNet1.static_ips jobs.myJob_z2.networks.myNet2.static_ips ))```
+
+
 ### Hmm.. How about auto-calculating static IPs for a BOSH manifest?
 
 `spruce` supports that too! Just use the same `(( static_ips(x, y, z) ))` syntax
 that you're used to with [spiff](https://github.com/cloudfoundry-incubator/spiff),
 to specify the offsets in the static IP range for a job's network.
 
-Behind the scenes, there are a couple behavior improvements upon spiff. First, 
+Behind the scenes, there are a couple behavior improvements upon spiff. First,
 since all the merging is done first, then post-processing, there's no need
 to worry about getting the instances + networks defined before `(( static_ips() ))`
 is merged in. Second, the error messaging output should be a lot better to aid in

--- a/dereferencer.go
+++ b/dereferencer.go
@@ -103,23 +103,23 @@ func (d *dereferencer) resolveKey(key string) (interface{}, error) {
 // PostProcess - resolves a value by seeing if it matches (( grab me.data )) or (( grab_if_exists me.data )) and retrieves me.data's value
 func (d *dereferencer) PostProcess(o interface{}, node string) (interface{}, string, error) {
 	d.recursiveCallBounder.reset()
+
+	var val interface{}
+	var err error
+
 	if should, args := parseGrabOp(o); should {
-		val, err := d.resolveGrab(node, args)
-		if err != nil {
-			return nil, "error", fmt.Errorf("%s: %s", node, err.Error())
-		}
-		DEBUG("%s: setting to %#v", node, val)
-		return val, "replace", nil
+		val, err = d.resolveGrab(node, args)
 	} else if should, args := parseGrabIfExistsOp(o); should {
-		val, err := d.resolveGrabIfExists(node, args)
-		if err != nil {
-			return nil, "error", fmt.Errorf("%s: %s", node, err.Error())
-		}
-		DEBUG("%s: setting to %#v", node, val)
-		return val, "replace", nil
+		val, err = d.resolveGrabIfExists(node, args)
 	} else {
 		return nil, "ignore", nil
 	}
+
+	if err != nil {
+		return nil, "error", fmt.Errorf("%s: %s", node, err.Error())
+	}
+	DEBUG("%s: setting to %#v", node, val)
+	return val, "replace", nil
 }
 
 const maxRecursiveCallLimit = 64

--- a/dereferencer.go
+++ b/dereferencer.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 )
 
+var errInfiniteRecursion = fmt.Errorf("possible infinite recursion detected in dereferencing")
+
 // DeReferencer is an implementation of PostProcessor to de-reference (( grab me.data )) calls
 type DeReferencer struct {
 	root map[interface{}]interface{}
@@ -25,8 +27,20 @@ func parseGrabOp(o interface{}) (bool, string) {
 	return false, ""
 }
 
-// resolve - resolves a set of tokens (literals or references), co-recursively with resolveKey()
-func (d DeReferencer) resolve(node string, args string) (interface{}, error) {
+// parseGrabIfExistsOp - determine if an object is a (( grab_if_exists ... )) call
+func parseGrabIfExistsOp(o interface{}) (bool, string) {
+	if o != nil && reflect.TypeOf(o).Kind() == reflect.String {
+		re := regexp.MustCompile(`^\Q((\E\s*grab_if_exists\s+(.+)\s*\Q))\E$`)
+		if re.MatchString(o.(string)) {
+			keys := re.FindStringSubmatch(o.(string))
+			return true, keys[1]
+		}
+	}
+	return false, ""
+}
+
+// resolveGrab - resolves a set of tokens (literals or references), co-recursively with resolveKey()
+func (d DeReferencer) resolveGrab(node string, args string) (interface{}, error) {
 	DEBUG("%s: resolving (( grab %s )))", node, args)
 	re := regexp.MustCompile(`\s+`)
 	targets := re.Split(strings.Trim(args, " \t\r\n"), -1)
@@ -52,6 +66,41 @@ func (d DeReferencer) resolve(node string, args string) (interface{}, error) {
 	return val, nil
 }
 
+// resolveGrabIfExists - resolves a set of tokens (literals or references), co-recursively with resolveKey()
+func (d DeReferencer) resolveGrabIfExists(node string, args string) (interface{}, error) {
+	DEBUG("%s: resolving (( grab_if_exists %s )))", node, args)
+	re := regexp.MustCompile(`\s+`)
+	targets := re.Split(strings.Trim(args, " \t\r\n"), -1)
+
+	if len(targets) <= 1 {
+		val, err := d.resolveKey(targets[0])
+		switch err {
+		case nil:
+			return val, nil
+		case errInfiniteRecursion:
+			return nil, err
+		default:
+			return nil, nil
+		}
+	}
+	val := []interface{}{}
+	for _, target := range targets {
+		v, err := d.resolveKey(target)
+		if err == errInfiniteRecursion {
+			return nil, err
+		} else if err != nil {
+			val = append(val, nil)
+		} else if v != nil && reflect.TypeOf(v).Kind() == reflect.Slice {
+			for i := 0; i < reflect.ValueOf(v).Len(); i++ {
+				val = append(val, reflect.ValueOf(v).Index(i).Interface())
+			}
+		} else {
+			val = append(val, v)
+		}
+	}
+	return val, nil
+}
+
 // resolveKey - resolves a single key reference, co-recursively with resolve()
 func (d DeReferencer) resolveKey(key string) (interface{}, error) {
 	DEBUG("  -> resolving reference to `%s`", key)
@@ -62,25 +111,42 @@ func (d DeReferencer) resolveKey(key string) (interface{}, error) {
 
 	if should, args := parseGrabOp(val); should {
 		if d.ttl -= 1; d.ttl <= 0 {
-			return "", fmt.Errorf("possible recursion detected in call to (( grab ))")
+			return "", errInfiniteRecursion
 		}
-		val, err = d.resolve(key, args)
+		val, err = d.resolveGrab(key, args)
 		d.ttl += 1
 		return val, err
+	} else if should, args := parseGrabIfExistsOp(val); should {
+		if d.ttl -= 1; d.ttl <= 0 {
+			return "", errInfiniteRecursion
+		}
+		val, err = d.resolveGrabIfExists(key, args)
+		d.ttl += 1
+		return val, err
+	} else {
+		return val, nil
 	}
-	return val, nil
 }
 
-// PostProcess - resolves a value by seeing if it matches (( grab me.data )) and retrieves me.data's value
+// PostProcess - resolves a value by seeing if it matches (( grab me.data )) or (( grab_if_exists me.data )) and retrieves me.data's value
 func (d DeReferencer) PostProcess(o interface{}, node string) (interface{}, string, error) {
 	if should, args := parseGrabOp(o); should {
 		d.ttl = 64
-		val, err := d.resolve(node, args)
+		val, err := d.resolveGrab(node, args)
 		if err != nil {
 			return nil, "error", fmt.Errorf("%s: %s", node, err.Error())
 		}
 		DEBUG("%s: setting to %#v", node, val)
 		return val, "replace", nil
+	} else if should, args := parseGrabIfExistsOp(o); should {
+		d.ttl = 64
+		val, err := d.resolveGrabIfExists(node, args)
+		if err != nil {
+			return nil, "error", fmt.Errorf("%s: %s", node, err.Error())
+		}
+		DEBUG("%s: setting to %#v", node, val)
+		return val, "replace", nil
+	} else {
+		return nil, "ignore", nil
 	}
-	return nil, "ignore", nil
 }

--- a/dereferencer_test.go
+++ b/dereferencer_test.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	. "github.com/smartystreets/goconvey/convey"
 	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestDeReferencerPostProcess(t *testing.T) {
@@ -18,70 +19,98 @@ func TestDeReferencerPostProcess(t *testing.T) {
 					"find": "other value",
 				},
 			},
+			"references": map[interface{}]interface{}{
+				"other": map[interface{}]interface{}{
+					"value": "(( grab othervalue.to.find ))",
+				},
+			},
+			"recursion":   "(( grab corecursion ))",
+			"corecursion": "(( grab recursion ))",
 		}}
-		Convey("returns nil, \"ignore\", nil", func() {
-			Convey("when given anything other than a string", func() {
+		Convey("when given anything other than a string", func() {
+			Convey("returns nil, \"ignore\", nil", func() {
 				val, action, err := deref.PostProcess(12345, "nodepath")
 				So(val, ShouldBeNil)
 				So(err, ShouldBeNil)
 				So(action, ShouldEqual, "ignore")
 			})
-			Convey("when given a '(( prune ))' string", func() {
+		})
+		Convey("when given a '(( prune ))' string", func() {
+			Convey("returns nil, \"ignore\", nil", func() {
 				val, action, err := deref.PostProcess("(( prune ))", "nodepath")
 				So(val, ShouldBeNil)
 				So(err, ShouldBeNil)
 				So(action, ShouldEqual, "ignore")
 			})
-			Convey("when given a non-'(( grab .* ))' string", func() {
+		})
+		Convey("when given a non-'(( grab .* ))' string", func() {
+			Convey("returns nil, \"ignore\", nil", func() {
 				val, action, err := deref.PostProcess("regular old string", "nodepath")
 				So(val, ShouldBeNil)
 				So(err, ShouldBeNil)
 				So(action, ShouldEqual, "ignore")
 			})
-			Convey("when given a quoted-'(( grab .* ))' string", func() {
+		})
+		Convey("when given a quoted-'(( grab .* ))' string", func() {
+			Convey("returns nil, \"ignore\", nil", func() {
 				val, action, err := deref.PostProcess("\"(( grab value.to.find ))\"", "nodepath")
 				So(val, ShouldBeNil)
 				So(err, ShouldBeNil)
 				So(action, ShouldEqual, "ignore")
 			})
 		})
-		Convey("Returns an error if resolveNode() had an error resolving", func() {
-			val, action, err := deref.PostProcess("(( grab value.to.retrieve ))", "nodepath")
-			So(val, ShouldBeNil)
-			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldStartWith, "nodepath: Unable to resolve `value.to.retrieve`:")
-			So(action, ShouldEqual, "error")
-		})
-		Convey("Returns value, \"replace\", nil on successful dereference", func() {
-			val, action, err := deref.PostProcess("(( grab value.to.find ))", "nodepath")
-			So(val, ShouldEqual, "dereferenced value")
-			So(err, ShouldBeNil)
-			So(action, ShouldEqual, "replace")
-		})
-		Convey("Handles multiple dereference requests inline by returning an array", func() {
-			val, action, err := deref.PostProcess("(( grab value.to.find othervalue.to.find ))", "nodepath")
-			So(val, ShouldResemble, []interface{}{
-				"dereferenced value",
-				"other value",
+		Convey("when given a (( grab .* )) string", func() {
+			Convey("Returns an error if resolveNode() had an error resolving", func() {
+				val, action, err := deref.PostProcess("(( grab value.to.retrieve ))", "nodepath")
+				So(val, ShouldBeNil)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldStartWith, "nodepath: Unable to resolve `value.to.retrieve`:")
+				So(action, ShouldEqual, "error")
 			})
-			So(err, ShouldBeNil)
-			So(action, ShouldEqual, "replace")
-		})
-		Convey("Errors on first problem of a multiple reference request", func() {
-			val, action, err := deref.PostProcess("(( grab value.to.find undefined.val othervalue.to.find ))", "nodepath")
-			So(val, ShouldBeNil)
-			So(action, ShouldEqual, "error")
-			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldEqual, "nodepath: Unable to resolve `undefined.val`: `undefined` could not be found in the YAML datastructure")
-		})
-		Convey("Extra whitespace is ok", func() {
-			val, action, err := deref.PostProcess("((	  grab value.to.find		othervalue.to.find     ))", "nodepath")
-			So(val, ShouldResemble, []interface{}{
-				"dereferenced value",
-				"other value",
+			Convey("Returns value, \"replace\", nil on successful dereference", func() {
+				val, action, err := deref.PostProcess("(( grab value.to.find ))", "nodepath")
+				So(val, ShouldEqual, "dereferenced value")
+				So(err, ShouldBeNil)
+				So(action, ShouldEqual, "replace")
 			})
-			So(err, ShouldBeNil)
-			So(action, ShouldEqual, "replace")
+			Convey("Handles multiple dereference requests inline by returning an array", func() {
+				val, action, err := deref.PostProcess("(( grab value.to.find othervalue.to.find ))", "nodepath")
+				So(val, ShouldResemble, []interface{}{
+					"dereferenced value",
+					"other value",
+				})
+				So(err, ShouldBeNil)
+				So(action, ShouldEqual, "replace")
+			})
+			Convey("Handles references that grab other references", func() {
+				val, action, err := deref.PostProcess("(( grab references.other.value ))", "nodepath")
+				So(val, ShouldEqual, "other value")
+				So(err, ShouldBeNil)
+				So(action, ShouldEqual, "replace")
+			})
+			Convey("Errors on first problem of a multiple reference request", func() {
+				val, action, err := deref.PostProcess("(( grab value.to.find undefined.val othervalue.to.find ))", "nodepath")
+				So(val, ShouldBeNil)
+				So(action, ShouldEqual, "error")
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "nodepath: Unable to resolve `undefined.val`: `undefined` could not be found in the YAML datastructure")
+			})
+			Convey("Extra whitespace is ok", func() {
+				val, action, err := deref.PostProcess("((	  grab value.to.find		othervalue.to.find     ))", "nodepath")
+				So(val, ShouldResemble, []interface{}{
+					"dereferenced value",
+					"other value",
+				})
+				So(err, ShouldBeNil)
+				So(action, ShouldEqual, "replace")
+			})
+			Convey("Avoids infinite recursion", func() {
+				val, action, err := deref.PostProcess("(( grab recursion ))", "nodepath")
+				So(val, ShouldBeNil)
+				So(action, ShouldEqual, "error")
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "nodepath: possible recursion detected in call to (( grab ))")
+			})
 		})
 	})
 }

--- a/dereferencer_test.go
+++ b/dereferencer_test.go
@@ -6,9 +6,9 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestDeReferencerPostProcess(t *testing.T) {
-	Convey("dereferencer.PostProces()", t, func() {
-		deref := DeReferencer{root: map[interface{}]interface{}{
+func TestDereferencerPostProcess(t *testing.T) {
+	Convey("dereferencer.PostProcess()", t, func() {
+		deref := NewDereferencer(map[interface{}]interface{}{
 			"value": map[interface{}]interface{}{
 				"to": map[interface{}]interface{}{
 					"find": "dereferenced value",
@@ -26,7 +26,7 @@ func TestDeReferencerPostProcess(t *testing.T) {
 			},
 			"recursion":   "(( grab corecursion ))",
 			"corecursion": "(( grab recursion ))",
-		}}
+		})
 		Convey("when given anything other than a string", func() {
 			Convey("returns nil, \"ignore\", nil", func() {
 				val, action, err := deref.PostProcess(12345, "nodepath")

--- a/main.go
+++ b/main.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"os"
 
+	"regexp"
+	"strings"
+
 	"github.com/geofffranks/simpleyaml" // FIXME: switch back to smallfish/simpleyaml after https://github.com/smallfish/simpleyaml/pull/1 is merged
 	"github.com/voxelbrain/goptions"
 	"gopkg.in/yaml.v2"
-	"regexp"
-	"strings"
 )
 
 // Current version of spruce
@@ -93,7 +94,7 @@ func main() {
 
 				m := &Merger{}
 				m.Visit(root, &StaticIPGenerator{root: root})
-				m.Visit(root, &DeReferencer{root: root})
+				m.Visit(root, NewDereferencer(root))
 				m.Visit(root, &Concatenator{root: root})
 
 				for _, toPrune := range options.Merge.Prune {


### PR DESCRIPTION
```
(( grab_if_exists some.ref other.ref unresolvable.ref ))
```

will behave like the `grab` equivalent except, instead of blowing up on `unresolvable.ref` it will replace that value with the null value, so the above would return an array of three things, the third being null.
