### PR TITLE
Support one-off builds with better version tracking

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# build.sh - Build wrapper
+#
+#  - changes build id from "master" to the commitish of HEAD
+#  - detects if there are uncommitted local changes
+#  - runs go build to build a spruce binary
+#  - undoes the change (so that it doesn't get committed)
+
+
+# track dirty changes in the local working copy
+if [[ $(git status --porcelain) != "" ]]; then
+	sed -i '' -e "s/var DIRTY = \".*\"/var DIRTY = \" with uncommitted local changes\"/" main.go
+fi
+
+# update BUILD to be the HEAD commit-ish
+sha1=$(git rev-list --abbrev-commit HEAD -n1)
+sed -i '' -e "s/var BUILD = \".*\"/var BUILD = \"${sha1}\"/" main.go
+
+# do the build
+go build .
+
+# put it all back
+sed -i '' -e "s/var BUILD = \".*\"/var BUILD = \"master\"/" main.go
+sed -i '' -e "s/var DIRTY = \".*\"/var DIRTY = \"\"/" main.go
+
+# what version?
+./spruce -v

--- a/ci/scripts/shipit.sh
+++ b/ci/scripts/shipit.sh
@@ -44,8 +44,8 @@ pushd $GOPATH/src/github/geofffranks/spruce
 
 godep restore
 
-go build .
-./spruce -v 2>&1 | grep "./spruce - Version ${version}"
+./build.sh
+./spruce -v 2>&1 | grep "./spruce - Version ${version} (${sha1})"
 
 goxc -bc="linux,!arm darwin,amd64" -d=$DIR/../../releases -pv=${version}
 

--- a/main.go
+++ b/main.go
@@ -13,6 +13,8 @@ import (
 
 // Current version of spruce
 var VERSION = "0.12.0" // SED MARKER FOR AUTO VERSION BUMPING
+var BUILD = "master" // updated by build.sh
+var DIRTY = "" // updated by build.sh
 
 var printfStdOut = func(format string, args ...interface{}) {
 	fmt.Fprintf(os.Stdout, format, args...)
@@ -77,7 +79,7 @@ func main() {
 	handleConcourseQuoting = options.Concourse
 
 	if options.Version {
-		printfStdErr("%s - Version %s\n", os.Args[0], VERSION)
+		printfStdErr("%s - Version %s (%s%s)\n", os.Args[0], VERSION, BUILD, DIRTY)
 		exit(0)
 		return
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -162,7 +162,7 @@ func TestMain(t *testing.T) {
 				stderr = ""
 				main()
 				So(stdout, ShouldEqual, "")
-				So(stderr, ShouldEqual, fmt.Sprintf("spruce - Version %s\n", VERSION))
+				So(stderr, ShouldEqual, fmt.Sprintf("spruce - Version %s (master)\n", VERSION))
 				So(rc, ShouldEqual, 0)
 			})
 			Convey("When '--version' is specified", func() {
@@ -171,7 +171,7 @@ func TestMain(t *testing.T) {
 				stderr = ""
 				main()
 				So(stdout, ShouldEqual, "")
-				So(stderr, ShouldEqual, fmt.Sprintf("spruce - Version %s\n", VERSION))
+				So(stderr, ShouldEqual, fmt.Sprintf("spruce - Version %s (master)\n", VERSION))
 				So(rc, ShouldEqual, 0)
 			})
 		})


### PR DESCRIPTION
Append the commit ID and whether or not any uncommitted changes were
present in the working directory when it was built.