### PR TITLE
Fix merge reference/copy bug in (( inject ... ))

### DIFF
--- a/evaluator_test.go
+++ b/evaluator_test.go
@@ -575,6 +575,98 @@ thing:
 				valueIs(ev, "thing.properties.foo", "bar")
 			})
 
+			Convey("uses deep-copy semantics to handle overrides correctly on template re-use", func() {
+				ev := &Evaluator{
+					Tree: YAML(
+						`meta:
+  template:
+    properties:
+      key: DEFAULT
+      sub:
+        key: DEFAULT
+foo:
+  <<<: (( inject meta.template ))
+  properties:
+    key: FOO
+    sub:
+      key: FOO
+bar:
+  <<<: (( inject meta.template ))
+  properties:
+    key: BAR
+    sub:
+      key: BAR
+boz:
+  <<<: (( inject meta.template ))
+  properties:
+    key: BOZ
+    sub:
+      key: BOZ
+`),
+				}
+
+				err := ev.DataFlow()
+				So(err, ShouldBeNil)
+
+				err = ev.Patch()
+				So(err, ShouldBeNil)
+
+				valueIs(ev, "foo.properties.key", "FOO")
+				valueIs(ev, "foo.properties.sub.key", "FOO")
+
+				valueIs(ev, "bar.properties.key", "BAR")
+				valueIs(ev, "bar.properties.sub.key", "BAR")
+
+				valueIs(ev, "boz.properties.key", "BOZ")
+				valueIs(ev, "boz.properties.sub.key", "BOZ")
+			})
+
+			Convey("uses deep-copy semantics for re-use of injected templates with embedded lists", func() {
+				ev := &Evaluator{
+					Tree: YAML(
+						`meta:
+  template:
+    properties:
+      key: DEFAULT
+      list:
+        - key: DEFAULT
+foo:
+  <<<: (( inject meta.template ))
+  properties:
+    key: FOO
+    list:
+      - key: FOO
+bar:
+  <<<: (( inject meta.template ))
+  properties:
+    key: BAR
+    list:
+      - key: BAR
+boz:
+  <<<: (( inject meta.template ))
+  properties:
+    key: BOZ
+    list:
+      - key: BOZ
+`),
+				}
+
+				err := ev.DataFlow()
+				So(err, ShouldBeNil)
+
+				err = ev.Patch()
+				So(err, ShouldBeNil)
+
+				valueIs(ev, "foo.properties.key", "FOO")
+				valueIs(ev, "foo.properties.list[0].key", "FOO")
+
+				valueIs(ev, "bar.properties.key", "BAR")
+				valueIs(ev, "bar.properties.list[0].key", "BAR")
+
+				valueIs(ev, "boz.properties.key", "BOZ")
+				valueIs(ev, "boz.properties.list[0].key", "BOZ")
+			})
+
 			Convey("handles static_ips() call and a subsequent grab", func() {
 				ev := &Evaluator{
 					Tree: YAML(

--- a/merge.go
+++ b/merge.go
@@ -59,6 +59,27 @@ func (m *Merger) Error() error {
 	return nil
 }
 
+func deepCopy(orig interface{}) interface{} {
+	switch orig.(type) {
+	case map[interface{}]interface{}:
+		x := map[interface{}]interface{}{}
+		for k, v := range orig.(map[interface{}]interface{}) {
+			x[k] = deepCopy(v)
+		}
+		return x
+
+	case []interface{}:
+		x := make([]interface{}, len(orig.([]interface{})))
+		for i, v := range orig.([]interface{}) {
+			x[i] = deepCopy(v)
+		}
+		return x
+
+	default:
+		return orig
+	}
+}
+
 // Merge ...
 func (m *Merger) Merge(a map[interface{}]interface{}, b map[interface{}]interface{}) error {
 	m.mergeMap(a, b, "$")
@@ -72,7 +93,7 @@ func (m *Merger) mergeMap(orig map[interface{}]interface{}, n map[interface{}]in
 			orig[k] = m.mergeObj(orig[k], val, path)
 		} else {
 			DEBUG("%s: not found upstream, adding it", path)
-			orig[k] = val
+			orig[k] = deepCopy(val)
 		}
 	}
 }


### PR DESCRIPTION
When injecting data with deep structures (nested maps) more than once
(i.e. for BOSH job definitions in multiple zones), spruce would fail.
This patch fixes that so that Merge() uses deep copy semantics to get a
completely separate subtree.

Thanks to lnguyen11288 for noticing / reporting this weird edge case.