### PR TITLE
Operand Expression Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ Arrays can be merged in three ways - prepending data, appending data, and comple
 
 To prune a map key from the final output<br>
 
-```spruce merge --prune key.1.to.prune --prune key.2.to.prune file1.yml file2.yml```
+```
+spruce merge --prune key.1.to.prune --prune key.2.to.prune file1.yml file2.yml
+```
 
 ### Referencing Other Data
 
@@ -118,7 +120,33 @@ pen:
 You can even reference multiple values at once, getting back an array of their data,
 for things like getting all IPs of multi-AZ jobs in a BOSH manifest, just do it like so:
 
-```(( grab jobs.myJob_z1.networks.myNet1.static_ips jobs.myJob_z2.networks.myNet2.static_ips ))```
+```
+(( grab jobs.myJob_z1.networks.myNet1.static_ips jobs.myJob_z2.networks.myNet2.static_ips ))
+```
+
+You can also provide alternatives to your `grab` operation, by
+using the `||` (or) operator:
+
+```
+key:      (( grab site.key || nil ))
+domain:   (( grab global.domain || "example.com" ))
+protocol: (( grab site.protocol || global.protocol || "http" ))
+```
+
+In these examples, if the referenced key does not exist, the next
+reference is attempted, or the literal value (nil, numbers or
+strings) is used.  Spruce recognizes the following keywords and
+uses the appropriate literal value:
+
+  - `nil`, `null` and `~` map to the YAML null value
+  - `true` is the YAML boolean value for truth
+  - `false` is the YAML boolean value for non-truth
+
+Other types of literals include double-quoted strings (with
+embedded double quotes escaped with a single backslash - \\),
+integer literals (a string of digits) and floating point literals
+(a string of digits, a period, and another string of digits).
+Scientific notation is not currently supported.
 
 ### Hmm.. How about auto-calculating static IPs for a BOSH manifest?
 

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,7 +1,42 @@
+# New Features
+
+New TRACE mode for debugging (activate via `--trace`) that will
+provide even more verbose debugging output.  Anything printed
+under `--debug` is not intended to help template authors
+troubleshoot merge, override, and operation problems with their
+templates.  `--trace`-level debugging is more for assisting spruce
+developers in reproducing buggy behavior, or for those of you who
+are *reallllly* interested in spruce internals!
+
+New `(( inject ... ))` operator for duplicating parts of the YAML
+structure elsewhere.  These injected sub-structures can then be
+overridden at the local level.
+
+Spruce internals got a major overhaul, including a new
+merge-eval-check phased approach to template rendering.  During
+each phase, spruce performs static data-flow analysis to determine
+what operations need to be called before what other operations.
+This leads to a better end-user experience, and fixes several
+classes of bugs related to implicit dependencies and call
+ordering.
+
+Operator arguments are now evaluated according to a simple set of
+expression rules, allowing alternatives to be specified like so:
+
+```
+(( grab first.option || second.option || nil ))
+```
+
+
 # Bug Fixes
 
-`(( concat value "string" ))` previously would crash spruce, if `value` was not a string in the yml output.
-This has been resolved
+Miscellaneous code cleanups, reformatting and documentation typo and broken
+link fixes went into this release.
+
+Specifically fixed some breakage related to numeric keys, as demonstrated in
+the examples in the README file.  To catch these in the future, the README
+examples are now integrated into the unit tests to verify the documentation.
+
 
 # Acknowledgements
 

--- a/evaluator.go
+++ b/evaluator.go
@@ -32,22 +32,20 @@ func (ev *Evaluator) DataFlow(phase OperatorPhase) ([]*Opcall, error) {
 
 	check = func(v interface{}) {
 		if s, ok := v.(string); ok {
-			op, err := ParseOpcall(s)
+			op, err := ParseOpcall(phase, s)
 			if err != nil {
 				errors.Append(err)
 			} else if op != nil {
-				if op.op.Phase() == phase {
-					op.where = ev.Here.Copy()
-					if canon, err := op.where.Canonical(ev.Tree); err == nil {
-						op.canonical = canon
-					} else {
-						op.canonical = op.where
-					}
-					all[op.canonical.String()] = op
-					TRACE("found an operation at %s: %s", op.where.String(), op.src)
-					TRACE("        (canonical at %s)", op.canonical.String())
-					locs = append(locs, op.canonical)
+				op.where = ev.Here.Copy()
+				if canon, err := op.where.Canonical(ev.Tree); err == nil {
+					op.canonical = canon
+				} else {
+					op.canonical = op.where
 				}
+				all[op.canonical.String()] = op
+				TRACE("found an operation at %s: %s", op.where.String(), op.src)
+				TRACE("        (canonical at %s)", op.canonical.String())
+				locs = append(locs, op.canonical)
 			}
 		} else {
 			scan(v)

--- a/evaluator_test.go
+++ b/evaluator_test.go
@@ -422,15 +422,27 @@ instances: (( grab meta.size || 42 ))
 nice:      (( grab meta.nice || -5 ))
 pi:        (( grab math.CONSTANTS.pi || 3.14159 ))
 delta:     (( grab meta.delta || .001 ))
+fbool:     (( grab meta.fbool || false ))
+tbool:     (( grab meta.tbool || true ))
+Fbool:     (( grab meta.fbool || False ))
+Tbool:     (( grab meta.tbool || True ))
+FBOOL:     (( grab meta.fbool || FALSE ))
+TBOOL:     (( grab meta.tbool || TRUE ))
 
 ---
 dataflow:
+- FBOOL: (( grab meta.fbool || FALSE ))
+- Fbool: (( grab meta.fbool || False ))
+- TBOOL: (( grab meta.tbool || TRUE ))
+- Tbool: (( grab meta.tbool || True ))
 - delta:     (( grab meta.delta || .001 ))
 - domain:    (( grab meta.domain || "default-domain" ))
 - env:       (( grab meta.env || "sandbox" ))
+- fbool: (( grab meta.fbool || false ))
 - instances: (( grab meta.size || 42 ))
 - nice:      (( grab meta.nice || -5 ))
 - pi:        (( grab math.CONSTANTS.pi || 3.14159 ))
+- tbool: (( grab meta.tbool || true ))
 
 ---
 meta:
@@ -441,6 +453,12 @@ instances: 42
 nice: -5
 pi: 3.14159
 delta: 0.001
+fbool: false
+Fbool: false
+FBOOL: false
+tbool: true
+Tbool: true
+TBOOL: true
 
 #########################################   handles simple reference-or-nil expressions
 ---

--- a/evaluator_test.go
+++ b/evaluator_test.go
@@ -608,6 +608,48 @@ api:
   endpoint: www.example.com
 
 
+#################################   handles multiple space-separated or-operands properly
+---
+meta:
+  foo: FOO
+  bar: BAR
+foobar: (( concat meta.foo || "foo"  meta.bar || "bar" ))
+fooboz: (( concat meta.foo || "foo"  meta.boz || "boz" ))
+
+---
+dataflow:
+- foobar: (( concat meta.foo || "foo"  meta.bar || "bar" ))
+- fooboz: (( concat meta.foo || "foo"  meta.boz || "boz" ))
+
+---
+meta:
+  foo: FOO
+  bar: BAR
+foobar: FOOBAR
+fooboz: FOOboz
+
+
+#################################   handles multiple comma-seaprated or-operands properly
+---
+meta:
+  foo: FOO
+  bar: BAR
+foobar: (( concat meta.foo || "foo", meta.bar || "bar" ))
+fooboz: (( concat meta.foo || "foo", meta.boz || "boz" ))
+
+---
+dataflow:
+- foobar: (( concat meta.foo || "foo", meta.bar || "bar" ))
+- fooboz: (( concat meta.foo || "foo", meta.boz || "boz" ))
+
+---
+meta:
+  foo: FOO
+  bar: BAR
+foobar: FOOBAR
+fooboz: FOOboz
+
+
 ############################################   can handle simple map-based Replace actions
 ---
 meta:

--- a/evaluator_test.go
+++ b/evaluator_test.go
@@ -497,6 +497,36 @@ meta:
 foo: SECOND
 
 
+#################################   skips short-circuited alternates in Data Flow analysis
+---
+meta:
+  foo: FOO
+  bar: (( grab meta.foo ))
+  boz: (( grab meta.foo ))
+
+foo: (( grab meta.bar || "foo?" || meta.boz ))
+# NOTE: meta.boz in $.foo is exempt from DFA, because the "foo?" literal
+#       will *always* stop evaluation of the expression
+
+bar: (( grab meta.xyzzy || "bar?" || meta.boz ))
+# NOTE: same with $.bar; meta.boz is not in play
+
+---
+dataflow:
+- bar: (( grab meta.xyzzy || "bar?" || meta.boz ))
+- meta.bar: (( grab meta.foo ))
+- meta.boz: (( grab meta.foo ))
+- foo: (( grab meta.bar || "foo?" || meta.boz ))
+
+---
+meta:
+  foo: FOO
+  bar: FOO
+  boz: FOO
+foo: FOO
+bar: bar?
+
+
 #####################################   handles Data Flow dependencies for all expressions
 ---
 meta:

--- a/evaluator_test.go
+++ b/evaluator_test.go
@@ -412,6 +412,7 @@ meta:
   domain: foo.bar
 domain: foo.bar
 
+
 #########################################   handles simple reference-or-literal expressions
 ---
 meta:
@@ -422,27 +423,19 @@ instances: (( grab meta.size || 42 ))
 nice:      (( grab meta.nice || -5 ))
 pi:        (( grab math.CONSTANTS.pi || 3.14159 ))
 delta:     (( grab meta.delta || .001 ))
-fbool:     (( grab meta.fbool || false ))
-tbool:     (( grab meta.tbool || true ))
-Fbool:     (( grab meta.fbool || False ))
-Tbool:     (( grab meta.tbool || True ))
-FBOOL:     (( grab meta.fbool || FALSE ))
-TBOOL:     (( grab meta.tbool || TRUE ))
+secure:    (( grab meta.secure || true ))
+online:    (( grab meta.online || false ))
 
 ---
 dataflow:
-- FBOOL: (( grab meta.fbool || FALSE ))
-- Fbool: (( grab meta.fbool || False ))
-- TBOOL: (( grab meta.tbool || TRUE ))
-- Tbool: (( grab meta.tbool || True ))
 - delta:     (( grab meta.delta || .001 ))
 - domain:    (( grab meta.domain || "default-domain" ))
 - env:       (( grab meta.env || "sandbox" ))
-- fbool: (( grab meta.fbool || false ))
 - instances: (( grab meta.size || 42 ))
 - nice:      (( grab meta.nice || -5 ))
+- online:    (( grab meta.online || false ))
 - pi:        (( grab math.CONSTANTS.pi || 3.14159 ))
-- tbool: (( grab meta.tbool || true ))
+- secure:    (( grab meta.secure || true ))
 
 ---
 meta:
@@ -453,12 +446,98 @@ instances: 42
 nice: -5
 pi: 3.14159
 delta: 0.001
-fbool: false
-Fbool: false
-FBOOL: false
-tbool: true
-Tbool: true
-TBOOL: true
+secure: true
+online: false
+
+
+#####################################   handles true, TRUE, and True as boolean keywords
+---
+TrUe: sure
+things:
+- (( grab meta.enoent || true ))
+- (( grab meta.enoent || TRUE ))
+- (( grab meta.enoent || True ))
+- (( grab meta.enoent || TrUe ))
+
+---
+dataflow:
+- things.0: (( grab meta.enoent || true ))
+- things.1: (( grab meta.enoent || TRUE ))
+- things.2: (( grab meta.enoent || True ))
+- things.3: (( grab meta.enoent || TrUe ))
+
+---
+TrUe: sure
+things:
+- true
+- true
+- true
+- sure
+
+
+#####################################   handles false, FALSE, and False as boolean keywords
+---
+FaLSe: why not?
+things:
+- (( grab meta.enoent || false ))
+- (( grab meta.enoent || FALSE ))
+- (( grab meta.enoent || False ))
+- (( grab meta.enoent || FaLSe ))
+
+---
+dataflow:
+- things.0: (( grab meta.enoent || false ))
+- things.1: (( grab meta.enoent || FALSE ))
+- things.2: (( grab meta.enoent || False ))
+- things.3: (( grab meta.enoent || FaLSe ))
+
+---
+FaLSe: why not?
+things:
+- false
+- false
+- false
+- why not?
+
+
+######################   handles ~, nil, Nil, NIL, null, Null, and NULL as the nil keyword
+---
+NuLL: 4 (haha ruby joke)
+things:
+- (( grab meta.enoent || ~ ))
+- (( grab meta.enoent || nil ))
+- (( grab meta.enoent || Nil ))
+- (( grab meta.enoent || NIL ))
+- (( grab meta.enoent || null ))
+- (( grab meta.enoent || Null ))
+- (( grab meta.enoent || NULL ))
+- (( grab meta.enoent || NuLL ))
+
+---
+dataflow:
+- things.0: (( grab meta.enoent || ~ ))
+- things.1: (( grab meta.enoent || nil ))
+- things.2: (( grab meta.enoent || Nil ))
+- things.3: (( grab meta.enoent || NIL ))
+- things.4: (( grab meta.enoent || null ))
+- things.5: (( grab meta.enoent || Null ))
+- things.6: (( grab meta.enoent || NULL ))
+- things.7: (( grab meta.enoent || NuLL ))
+
+---
+NuLL: 4 (haha ruby joke)
+things:
+- null
+- null
+- null
+- null
+- null
+- null
+- null
+- 4 (haha ruby joke)
+
+
+
 
 #########################################   handles simple reference-or-nil expressions
 ---

--- a/evaluator_test.go
+++ b/evaluator_test.go
@@ -460,6 +460,48 @@ env: ~
 site: ~
 
 
+##################################   stops at the first concrete (possibly false) expression
+---
+meta:
+  other: FAIL
+
+#
+# should stop here ----------.   (because it's resolvable, even if it
+#                            |    evaluates to a traditionally non-true value)
+#                            v
+foo: (( grab meta.enoent || false || meta.other || "failed" ))
+
+---
+dataflow:
+- foo: (( grab meta.enoent || false || meta.other || "failed" ))
+
+---
+meta:
+  other: FAIL
+foo: false
+
+
+##################################   stops at the first concrete (possibly 0) expression
+---
+meta:
+  other: FAIL
+
+#
+# should stop here ----------.   (because it's resolvable, even if it
+#                            |    evaluates to a traditionally non-true value)
+#                            v
+foo: (( grab meta.enoent || 0 || meta.other || "failed" ))
+
+---
+dataflow:
+- foo: (( grab meta.enoent || 0 || meta.other || "failed" ))
+
+---
+meta:
+  other: FAIL
+foo: 0
+
+
 ##################################   stops at the first concrete (possibly nil) expression
 ---
 meta:

--- a/op_null.go
+++ b/op_null.go
@@ -20,11 +20,11 @@ func (NullOperator) Phase() OperatorPhase {
 }
 
 // Dependencies ...
-func (NullOperator) Dependencies(_ *Evaluator, _ []interface{}, _ []*Cursor) []*Cursor {
+func (NullOperator) Dependencies(_ *Evaluator, _ []*Expr, _ []*Cursor) []*Cursor {
 	return []*Cursor{}
 }
 
 // Run ...
-func (n NullOperator) Run(ev *Evaluator, args []interface{}) (*Response, error) {
+func (n NullOperator) Run(ev *Evaluator, _ []*Expr) (*Response, error) {
 	return nil, fmt.Errorf("(( %s )) operator not defined", n.Missing)
 }

--- a/op_param.go
+++ b/op_param.go
@@ -18,13 +18,14 @@ func (ParamOperator) Phase() OperatorPhase {
 }
 
 // Dependencies ...
-func (ParamOperator) Dependencies(_ *Evaluator, _ []interface{}, _ []*Cursor) []*Cursor {
+func (ParamOperator) Dependencies(_ *Evaluator, _ []*Expr, _ []*Cursor) []*Cursor {
 	return []*Cursor{}
 }
 
 // Run ...
-func (ParamOperator) Run(ev *Evaluator, args []interface{}) (*Response, error) {
-	return nil, fmt.Errorf("%s", args[0])
+func (ParamOperator) Run(ev *Evaluator, args []*Expr) (*Response, error) {
+	v, _ := args[0].Evaluate(ev.Tree) // FIXME: there are lots of assumptions here...
+	return nil, fmt.Errorf("%s", v)
 }
 
 func init() {

--- a/operator.go
+++ b/operator.go
@@ -371,7 +371,7 @@ func ParseOpcall(phase OperatorPhase, src string) (*Opcall, error) {
 				TRACE("expr: pushing || expr-op onto the stack")
 				op = &Expr{Type: LogicalOr}
 
-			case arg == "nil" || arg == "null" || arg == "~" || arg == "Nil" || arg == "Null" || arg == "NILL" || arg == "NULL":
+			case arg == "nil" || arg == "null" || arg == "~" || arg == "Nil" || arg == "Null" || arg == "NIL" || arg == "NULL":
 				DEBUG("  #%d: parsed the nil value token '%s'", i, arg)
 				push(&Expr{Type: Literal, Literal: nil})
 

--- a/operator.go
+++ b/operator.go
@@ -331,6 +331,14 @@ func ParseOpcall(phase OperatorPhase, src string) (*Opcall, error) {
 				DEBUG("  #%d: parsed the nil value token '%s'", i, arg)
 				stack = append(stack, &Expr{Type: Literal, Literal: nil})
 
+			case arg == "false" || arg == "False" || arg == "FALSE":
+				DEBUG("  #%d: parsed the false value token '%s'", i, arg)
+				stack = append(stack, &Expr{Type: Literal, Literal: false})
+
+			case arg == "true" || arg == "True" || arg == "TRUE":
+				DEBUG("  #%d: parsed the true value token '%s'", i, arg)
+				stack = append(stack, &Expr{Type: Literal, Literal: true})
+
 			default:
 				c, err := ParseCursor(arg)
 				if err != nil {

--- a/operator.go
+++ b/operator.go
@@ -309,7 +309,7 @@ func ParseOpcall(phase OperatorPhase, src string) (*Opcall, error) {
 				DEBUG("  #%d: parsed as unquoted floating point literal '%s'", i, arg)
 				v, err := strconv.ParseFloat(arg, 64)
 				if err != nil {
-					DEBUG("  #%d: %s is not parseable as a floatin point number: %s", i, arg, err)
+					DEBUG("  #%d: %s is not parsable as a floating point number: %s", i, arg, err)
 					return args, err
 				}
 				stack = append(stack, &Expr{Type: Literal, Literal: v})
@@ -318,7 +318,7 @@ func ParseOpcall(phase OperatorPhase, src string) (*Opcall, error) {
 				DEBUG("  #%d: parsed as unquoted integer literal '%s'", i, arg)
 				v, err := strconv.ParseInt(arg, 10, 64)
 				if err != nil {
-					DEBUG("  #%d: %s is not parseable as an integer: %s", i, arg, err)
+					DEBUG("  #%d: %s is not parsable as an integer: %s", i, arg, err)
 					return args, err
 				}
 				stack = append(stack, &Expr{Type: Literal, Literal: v})

--- a/operator.go
+++ b/operator.go
@@ -327,7 +327,7 @@ func ParseOpcall(phase OperatorPhase, src string) (*Opcall, error) {
 				DEBUG("  #%d: parsed logical-or operator, '||'", i)
 				stack = append(stack, &Expr{Type: LogicalOr})
 
-			case arg == "nil" || arg == "null" || arg == "~":
+			case arg == "nil" || arg == "null" || arg == "~" || arg == "Nil" || arg == "Null" || arg == "NILL" || arg == "NULL":
 				DEBUG("  #%d: parsed the nil value token '%s'", i, arg)
 				stack = append(stack, &Expr{Type: Literal, Literal: nil})
 


### PR DESCRIPTION
All operators can now use the more flexible expression system for
operands, which is comprised of the following expressions:

  - A literal value (string, integer, floating point number, etc.)
  - A reference to some other part of the YAML document
  - The nil-value (null, ~ or ni)
  - Some combination of the above, using the alternates / logical-or
    operator, `||'