### PR TITLE
New `(( vault ... ))` operator

### DIFF
--- a/op_vault.go
+++ b/op_vault.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// The VaultOperator provides a means of injecting credentials and
+// other secrets from a Vault (vaultproject.io) Secure Key Storage
+// instance.
+type VaultOperator struct{}
+
+// Setup ...
+func (VaultOperator) Setup() error {
+	return nil
+}
+
+// Phase identifies what phase of document management the vault
+// operator should be evaulated in.  Vault lives in the Eval phase
+func (VaultOperator) Phase() OperatorPhase {
+	return EvalPhase
+}
+
+// Dependencies collects implicit dependencies that a given
+// `(( vault ... ))` call has.  There are none.
+func (VaultOperator) Dependencies(_ *Evaluator, _ []*Expr, _ []*Cursor) []*Cursor {
+	return []*Cursor{}
+}
+
+// Run executes the `(( vault ... ))` operator call, which entails
+// interacting with the (unsealed) Vault instance to retrieve the
+// given secrets.
+func (VaultOperator) Run(ev *Evaluator, args []*Expr) (*Response, error) {
+	DEBUG("running (( vault ... )) operation at $.%s", ev.Here)
+	defer DEBUG("done with (( vault ... )) operation at $.%s\n", ev.Here)
+
+	// syntax: (( vault "secret/path:key" ))
+	if len(args) != 1 {
+		return nil, fmt.Errorf("vault operator requires at least one argument")
+	}
+
+	v, err := args[0].Resolve(ev.Tree)
+	if err != nil {
+		DEBUG("  arg[0]: failed to resolve expression to a concrete value")
+		DEBUG("     [0]: error was: %s", err)
+		return nil, err
+	}
+
+	var key string
+	switch v.Type {
+	case Literal:
+		DEBUG("  arg[0]: using string literal '%v'", v.Literal)
+		key = fmt.Sprintf("%v", v.Literal)
+
+	case Reference:
+		DEBUG("  arg[0]: trying to resolve reference $.%s", v.Reference)
+		s, err := v.Reference.Resolve(ev.Tree)
+		if err != nil {
+			DEBUG("     [0]: resolution failed\n    error: %s", err)
+			return nil, fmt.Errorf("Unable to resolve `%s`: %s", v.Reference, err)
+		}
+
+		switch s.(type) {
+		case map[interface{}]interface{}:
+			DEBUG("  arg[0]: %v is not a string scalar", s)
+			return nil, fmt.Errorf("tried to concat %s, which is not a string scalar", v.Reference)
+
+		case []interface{}:
+			DEBUG("  arg[0]: %v is not a string scalar", s)
+			return nil, fmt.Errorf("tried to concat %s, which is not a string scalar", v.Reference)
+
+		default:
+			key = fmt.Sprintf("%v", s)
+		}
+
+	default:
+		DEBUG("  arg[0]: I don't know what to do with '%v'", args[0])
+		return nil, fmt.Errorf("vault operator only accepts string literals and key reference arguments")
+	}
+	DEBUG("     [0]: Using vault key '%s'\n", key)
+
+	secret := "REDACTED"
+	if os.Getenv("VAULT_ADDR") != "" && os.Getenv("VAULT_TOKEN") != "" {
+		parts := strings.SplitN(key, ":", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid argument %s; must be in the form path/to/secret:key", key)
+		}
+		secret, err = getVaultSecret(parts[0], parts[1])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &Response{
+		Type:  Replace,
+		Value: secret,
+	}, nil
+}
+
+func init() {
+	RegisterOp("vault", VaultOperator{})
+}
+
+/****** VAULT INTEGRATION ***********************************/
+
+func getVaultSecret(secret string, subkey string) (string, error) {
+	vault := os.Getenv("VAULT_ADDR")
+	DEBUG("  accessing the vault at %s", vault)
+
+	url := fmt.Sprintf("%s/v1/%s", vault, secret)
+	DEBUG("  crafting GET %s", url)
+
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		DEBUG("    !! failed to craft API request:\n    !! %s\n", err)
+		return "", fmt.Errorf("failed to retrieve %s:%s from Vault (%s): %s",
+			secret, subkey, vault, err)
+	}
+	req.Header.Add("X-Vault-Token", os.Getenv("VAULT_TOKEN"))
+
+	DEBUG("  issuing GET %s", url)
+	res, err := client.Do(req)
+	if err != nil {
+		DEBUG("    !! failed to issue API request:\n    !! %s\n", err)
+		return "", fmt.Errorf("failed to retrieve %s:%s from Vault (%s): %s",
+			secret, subkey, vault, err)
+	}
+	defer res.Body.Close()
+
+	TRACE("    reading response body")
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		DEBUG("    !! failed to read JSON:\n    !! %s\n", err)
+		return "", fmt.Errorf("failed to retrieve %s:%s from Vault (%s): %s",
+			secret, subkey, vault, err)
+	}
+
+	TRACE("    decoding raw JSON:\n%s\n", string(b))
+	var raw struct {
+		Data   map[string]interface{}
+		Errors []string
+	}
+	err = json.NewDecoder(bytes.NewReader(b)).Decode(&raw)
+	if err != nil {
+		DEBUG("    !! failed to decode JSON:\n    !! %s\n", err)
+		return "", fmt.Errorf("bad JSON response received from Vault: \"%s\"", string(b))
+	}
+	if len(raw.Errors) > 0 {
+		DEBUG("    !! error: %s", raw.Errors[0])
+		return "", fmt.Errorf("failed to retrieve %s:%s from Vault (%s): %s",
+			secret, subkey, vault, raw.Errors[0])
+	}
+
+	DEBUG("  extracting the [%s] subkey from the secret", subkey)
+	v, ok := raw.Data[subkey]
+	if !ok {
+		DEBUG("    !! %s:%s not found!\n", secret, subkey)
+		return "", fmt.Errorf("secret %s:%s not found", secret, subkey)
+	}
+	if _, ok := v.(string); !ok {
+		DEBUG("    !! %s:%s is not a string!\n", secret, subkey)
+		return "", fmt.Errorf("secret %s:%s is not a string", secret, subkey)
+	}
+
+	DEBUG("  success.")
+	return v.(string), nil
+}

--- a/op_vault.go
+++ b/op_vault.go
@@ -41,7 +41,7 @@ func (VaultOperator) Run(ev *Evaluator, args []*Expr) (*Response, error) {
 
 	// syntax: (( vault "secret/path:key" ))
 	if len(args) != 1 {
-		return nil, fmt.Errorf("vault operator requires at least one argument")
+		return nil, fmt.Errorf("vault operator requires exactly one argument")
 	}
 
 	v, err := args[0].Resolve(ev.Tree)
@@ -68,11 +68,11 @@ func (VaultOperator) Run(ev *Evaluator, args []*Expr) (*Response, error) {
 		switch s.(type) {
 		case map[interface{}]interface{}:
 			DEBUG("  arg[0]: %v is not a string scalar", s)
-			return nil, fmt.Errorf("tried to concat %s, which is not a string scalar", v.Reference)
+			return nil, fmt.Errorf("tried to look up $.%s, which is not a string scalar", v.Reference)
 
 		case []interface{}:
 			DEBUG("  arg[0]: %v is not a string scalar", s)
-			return nil, fmt.Errorf("tried to concat %s, which is not a string scalar", v.Reference)
+			return nil, fmt.Errorf("tried to look up $.%s, which is not a string scalar", v.Reference)
 
 		default:
 			key = fmt.Sprintf("%v", s)

--- a/vault_test.go
+++ b/vault_test.go
@@ -210,7 +210,7 @@ secret: (( vault ))
 
 ---
 1 error(s) detected:
- - $.secret: vault operator requires at least one argument
+ - $.secret: vault operator requires exactly one argument
 
 #########################################  fails on non-existent reference
 ---
@@ -229,7 +229,7 @@ secret: (( vault $.meta ))
 
 ---
 1 error(s) detected:
- - $.secret: tried to concat meta, which is not a string scalar
+ - $.secret: tried to look up $.meta, which is not a string scalar
 
 ##################################################  fails on list reference
 ---
@@ -239,7 +239,7 @@ secret: (( vault $.meta ))
 
 ---
 1 error(s) detected:
- - $.secret: tried to concat meta, which is not a string scalar
+ - $.secret: tried to look up $.meta, which is not a string scalar
 
 #########################################  fails on non-existent credentials
 ---

--- a/vault_test.go
+++ b/vault_test.go
@@ -1,0 +1,290 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"bufio"
+	"github.com/geofffranks/simpleyaml"
+	. "github.com/smartystreets/goconvey/convey"
+	"gopkg.in/yaml.v2"
+	"regexp"
+	"strings"
+	"testing"
+	"os"
+)
+
+func TestVault(t *testing.T) {
+	YAML := func(s string) map[interface{}]interface{} {
+		y, err := simpleyaml.NewYaml([]byte(s))
+		So(err, ShouldBeNil)
+
+		data, err := y.Map()
+		So(err, ShouldBeNil)
+
+		return data
+	}
+	ToYAML := func(tree map[interface{}]interface{}) string {
+		y, err := yaml.Marshal(tree)
+		So(err, ShouldBeNil)
+		return string(y)
+	}
+	ReYAML := func(s string) string {
+		return ToYAML(YAML(s))
+	}
+	RunTests := func(src string) {
+		var test, input, output string
+		var current *string
+		testPat := regexp.MustCompile(`^##+\s+(.*)\s*$`)
+
+		convey := func() {
+			if test != "" {
+				Convey(test, func() {
+					ev := &Evaluator{Tree: YAML(input)}
+					err := ev.RunPhase(EvalPhase)
+					So(err, ShouldBeNil)
+					So(ToYAML(ev.Tree), ShouldEqual, ReYAML(output))
+				})
+			}
+		}
+
+		s := bufio.NewScanner(strings.NewReader(src))
+		for s.Scan() {
+			if testPat.MatchString(s.Text()) {
+				m := testPat.FindStringSubmatch(s.Text())
+				convey()
+				test, input, output = m[1], "", ""
+				continue
+			}
+
+			if s.Text() == "---" {
+				if input == "" {
+					current = &input
+				} else {
+					current = &output
+				}
+				continue
+			}
+
+			if current != nil {
+				*current = *current + s.Text() + "\n"
+			}
+		}
+		convey()
+	}
+
+	RunErrorTests := func(src string) {
+		var test, input, errors string
+		var current *string
+		testPat := regexp.MustCompile(`^##+\s+(.*)\s*$`)
+
+		convey := func() {
+			if test != "" {
+				Convey(test, func() {
+					ev := &Evaluator{Tree: YAML(input)}
+					err := ev.RunPhase(EvalPhase)
+					So(err, ShouldNotBeNil)
+					So(strings.Trim(err.Error(), " \t"), ShouldEqual, errors)
+				})
+			}
+		}
+
+		s := bufio.NewScanner(strings.NewReader(src))
+		for s.Scan() {
+			if testPat.MatchString(s.Text()) {
+				m := testPat.FindStringSubmatch(s.Text())
+				convey()
+				test, input, errors = m[1], "", ""
+				continue
+			}
+
+			if s.Text() == "---" {
+				if input == "" {
+					current = &input
+				} else {
+					current = &errors
+				}
+				continue
+			}
+
+			if current != nil {
+				*current = *current + s.Text() + "\n"
+			}
+		}
+		convey()
+	}
+
+	Convey("Disconnected Vault", t, func() {
+		os.Setenv("VAULT_ADDR", "")
+		os.Setenv("VAULT_TOKEN", "")
+
+		RunTests(`
+#############################################  emits REDACTED for no VAULT_* ENV
+---
+secret: (( vault "secret/hand:shake" ))
+
+---
+secret: REDACTED
+`)
+
+		os.Setenv("VAULT_ADDR", "something")
+		os.Setenv("VAULT_TOKEN", "")
+		RunTests(`
+#############################################  emits REDACTED for no VAULT_TOKEN
+---
+secret: (( vault "secret/hand:shake" ))
+
+---
+secret: REDACTED
+`)
+
+		os.Setenv("VAULT_ADDR", "")
+		os.Setenv("VAULT_TOKEN", "something")
+		RunTests(`
+#############################################  emits REDACTED for no VAULT_ADDR
+---
+secret: (( vault "secret/hand:shake" ))
+
+---
+secret: REDACTED
+`)
+	})
+
+	Convey("Connected Vault", t, func() {
+		mock := httptest.NewServer(
+			http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {
+					if r.Header.Get("X-Vault-Token") != "sekrit-toekin" {
+						w.WriteHeader(403)
+						fmt.Fprintf(w, `{"errors":["missing client token"]}`)
+						return
+					}
+					switch r.URL.Path {
+					case "/v1/secret/hand":
+						w.WriteHeader(200)
+						fmt.Fprintf(w, `{"data":{"shake":"knock, knock"}}`)
+					case "/v1/secret/admin":
+						w.WriteHeader(200)
+						fmt.Fprintf(w, `{"data":{"username":"admin","password":"x12345"}}`)
+					case "/v1/secret/key":
+						w.WriteHeader(200)
+						fmt.Fprintf(w, `{"data":{"test":"testing"}}`)
+					case "/v1/secret/malformed":
+						w.WriteHeader(200)
+						fmt.Fprintf(w, `wait, this isn't JSON`)
+					case "/v1/secret/structure":
+						w.WriteHeader(200)
+						fmt.Fprintf(w, `{"data":{"data":[1,2,3]}}`)
+					default:
+						w.WriteHeader(404)
+						fmt.Fprintf(w, `{"errors":[]}`)
+					}
+				},
+			),
+		)
+		defer mock.Close()
+
+		os.Setenv("VAULT_ADDR", mock.URL)
+		os.Setenv("VAULT_TOKEN", "sekrit-toekin")
+		RunTests(`
+################################################  emits sensitive credentials
+---
+meta: secret/key:test
+secret: (( vault "secret/hand:shake" ))
+username: (( vault "secret/admin:username" ))
+password: (( vault "secret/admin:password" ))
+key: (( vault $.meta ))
+
+---
+meta: secret/key:test
+secret: knock, knock
+username: admin
+password: x12345
+key: testing
+`)
+
+		RunErrorTests(`
+#########################################  fails when missing its argument
+---
+secret: (( vault ))
+
+---
+1 error(s) detected:
+ - $.secret: vault operator requires at least one argument
+
+#########################################  fails on non-existent reference
+---
+meta: {}
+secret: (( vault $.meta.key ))
+
+---
+1 error(s) detected:
+ - $.secret: Unable to resolve `+"`"+`meta.key`+"`"+`: `+"`"+`$.meta.key`+"`"+` could not be found in the YAML datastructure
+
+####################################################  fails on map reference
+---
+meta:
+  key: secret/hand:shake
+secret: (( vault $.meta ))
+
+---
+1 error(s) detected:
+ - $.secret: tried to concat meta, which is not a string scalar
+
+##################################################  fails on list reference
+---
+meta:
+  - first
+secret: (( vault $.meta ))
+
+---
+1 error(s) detected:
+ - $.secret: tried to concat meta, which is not a string scalar
+
+#########################################  fails on non-existent credentials
+---
+secret: (( vault "secret/e:noent" ))
+
+---
+1 error(s) detected:
+ - $.secret: secret secret/e:noent not found
+
+##############################################  fails on non-string argument
+---
+secret: (( vault 42 ))
+
+---
+1 error(s) detected:
+ - $.secret: invalid argument 42; must be in the form path/to/secret:key
+
+#################################################  fails on non-JSON response
+---
+secret: (( vault "secret/malformed:key" ))
+
+---
+1 error(s) detected:
+ - $.secret: bad JSON response received from Vault: "wait, this isn't JSON"
+
+#################################################  fails on non-string data
+---
+secret: (( vault "secret/structure:data" ))
+
+---
+1 error(s) detected:
+ - $.secret: secret secret/structure:data is not a string
+
+`)
+
+		os.Setenv("VAULT_TOKEN", "incorrect")
+		RunErrorTests(`
+################################################  fails on with a bad token
+---
+secret: (( vault "secret/hand:shake" ))
+
+---
+1 error(s) detected:
+ - $.secret: failed to retrieve secret/hand:shake from Vault (`+os.Getenv("VAULT_ADDR")+`): missing client token
+
+`)
+	})
+}


### PR DESCRIPTION
Integrates with Hashicorp's Vault (vaultproject.io) offering via
cli/exec to extract secrets from an unsealed Vault and put them in a
final merged manifest.  Running with VAULT_ADDR="" will disable this,
and redner all call sites as the string "REDACTED" (for commiting to
git, for example)