### PR TITLE
Handle VAULT_TOKEN better for interactive use

### DIFF
--- a/assets/home/auth/.vault-token
+++ b/assets/home/auth/.vault-token
@@ -1,0 +1,1 @@
+sekrit-toekin

--- a/op_vault.go
+++ b/op_vault.go
@@ -85,7 +85,17 @@ func (VaultOperator) Run(ev *Evaluator, args []*Expr) (*Response, error) {
 	DEBUG("     [0]: Using vault key '%s'\n", key)
 
 	secret := "REDACTED"
-	if os.Getenv("VAULT_ADDR") != "" && os.Getenv("VAULT_TOKEN") != "" {
+	if os.Getenv("VAULT_ADDR") != "" {
+		if os.Getenv("VAULT_TOKEN") == "" {
+			b, err := ioutil.ReadFile(fmt.Sprintf("%s/.vault-token", os.Getenv("HOME")))
+			if err == nil {
+				os.Setenv("VAULT_TOKEN", strings.TrimSuffix(string(b), "\n"))
+			}
+		}
+
+		if os.Getenv("VAULT_TOKEN") == "" {
+			return nil, fmt.Errorf("VAULT_ADDR specified, but no VAULT_TOKEN or ~/.vault-token found")
+		}
 		parts := strings.SplitN(key, ":", 2)
 		if len(parts) != 2 {
 			return nil, fmt.Errorf("invalid argument %s; must be in the form path/to/secret:key", key)


### PR DESCRIPTION
If VAULT_TOKEN is not found in the environment (or is empty), and there
exists a file $HOME/.vault-token, read that file and use its contents as
the token.  This file is created by a call to `vault auth`.

This still supports the CI pipeline use case, but makes things easier on
humans trying to generate sensitive BOSH manifests with Spruce + Vault

Fixes #90