### PR TITLE
Always set VAULT_TOKEN header, even during redirects

### DIFF
--- a/op_vault.go
+++ b/op_vault.go
@@ -115,7 +115,15 @@ func getVaultSecret(secret string, subkey string) (string, error) {
 	url := fmt.Sprintf("%s/v1/%s", vault, secret)
 	DEBUG("  crafting GET %s", url)
 
-	client := &http.Client{}
+	client := &http.Client{
+		CheckRedirect: func (req *http.Request, via []*http.Request) error {
+			if len(via) > 10 {
+				return fmt.Errorf("stopped after 10 redirects")
+			}
+			req.Header.Add("X-Vault-Token", os.Getenv("VAULT_TOKEN"))
+			return nil
+		},
+	}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		DEBUG("    !! failed to craft API request:\n    !! %s\n", err)


### PR DESCRIPTION
In HA-modes, targetting a non-leader Vault causes that API endpoint to
issue 307 Temporary Redirects directing the client at the correct
(leader) API endpoint.  The default redirection logic in net/http fails
to set the X-Vault-Token header on these subsequent requests, so we
override the policy function here and explicitly set it.

Fixes #91