### PR TITLE
Improve build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -36,6 +36,9 @@ fi
 # do the build
 if [[ -n ${IN_RELEASE} ]]; then
 	goxc -bc="linux,!arm darwin,amd64" -d=$DIR/../../releases -pv=${version}
+elif [[ -n ${1} ]]; then
+	# allow usage like `./build.sh linux/amd64`
+	gox -osarch="${@}"
 fi
 
 go build .

--- a/main.go
+++ b/main.go
@@ -112,7 +112,11 @@ func main() {
 	handleConcourseQuoting = options.Concourse
 
 	if options.Version {
-		printfStdErr("%s - Version %s (%s%s)\n", os.Args[0], VERSION, BUILD, DIRTY)
+		plus := ""
+		if BUILD != "release" {
+			plus = "+"
+		}
+		printfStdErr("%s - Version %s%s (%s%s)\n", os.Args[0], VERSION, plus, BUILD, DIRTY)
 		exit(0)
 		return
 	}


### PR DESCRIPTION
- Default adhoc-builds (go build) to a special version string
- Allow build.sh to generate bins on other platforms via gox
- Show version as x.y.z+ for non-release builds