### PR TITLE
Switch to Gox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .DS_Store
 spruce
-spruce_*amd64
-spruce-*.gz
+spruce-*
 credentials.yml
 releases

--- a/build.sh
+++ b/build.sh
@@ -35,10 +35,11 @@ fi
 
 # do the build
 if [[ -n ${IN_RELEASE} ]]; then
-	goxc -bc="linux,!arm darwin,amd64" -d=$DIR/../../releases -pv=${version}
+	mkdir -p releases
+	gox -osarch="linux/amd64 linux/386 darwin/amd64" --output="${OUTPUT:-releases}/spruce-{{.OS}}-{{.Arch}}"
 elif [[ -n ${1} ]]; then
 	# allow usage like `./build.sh linux/amd64`
-	gox -osarch="$*"
+	gox -osarch="$*" --output="spruce-{{.OS}}-{{.Arch}}"
 fi
 
 go build .

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -98,8 +98,9 @@ jobs:
         path: ./spruce/ci/scripts/shipit.sh
         args: []
       params:
-        release_name: "Spruce Release"
-        promotion_branch: master
+        RELEASE:      Spruce Release
+        BRANCH:       master
+        VERSION_FROM: ../version/number
   - put: git-spruce
     params:
       repository: create-final-release/spruce
@@ -113,10 +114,7 @@ jobs:
         tag: create-final-release/spruce/releases/tag
         body: create-final-release/spruce/releases/notes.md
         globs:
-        - create-final-release/spruce/releases/**/spruce_*.tar.gz
-        - create-final-release/spruce/releases/**/spruce_*.zip
-        - create-final-release/spruce/releases/**/LICENSE
-        - create-final-release/spruce/releases/**/README.md
+        - create-final-release/spruce/releases/spruce-*
 
 
 resources:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -99,7 +99,6 @@ jobs:
         args: []
       params:
         RELEASE:      Spruce Release
-        BRANCH:       master
         VERSION_FROM: ../version/number
   - put: git-spruce
     params:

--- a/ci/scripts/shipit.sh
+++ b/ci/scripts/shipit.sh
@@ -28,9 +28,6 @@ PACKAGE=github.com/geofffranks/spruce
 #   VERSION - The version to bump to.  If not set, the version number
 #             *must* be found in the file ${VERSION_FROM} (which must
 #             contain the path to a real, regular file)
-#   BRANCH  - The name of the branch to merge into the checked-out
-#             copy before committing version bump changes.
-#             (defaults to "master")
 #
 
 function auto_sed() {
@@ -73,10 +70,6 @@ if [[ -z "${RELEASE:-}" ]]; then
 	RELEASE="Spruce Release"
 fi
 
-if [[ -z "${BRANCH:-}" ]]; then
-	BRANCH="master"
-fi
-
 echo ">> Bumping ${RELEASE} to ${VERSION}"
 auto_sed "s/var VERSION = \".*\"/var VERSION = \"${VERSION}\"/" main.go
 
@@ -90,10 +83,6 @@ fi
 set -e
 
 echo ">> Running git operations as $(git config --global user.name) <$(git config --global user.email)>"
-
-echo ">> Merging ${BRANCH} into checked-out copy before final commit"
-git merge --no-edit ${BRANCH}
-git status
 echo ">> Adding all modified files"
 git add -A
 git status

--- a/ci/scripts/shipit.sh
+++ b/ci/scripts/shipit.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -ex
+set -e
+[ -n "${DEBUG}" ] && set -x
 PACKAGE=github.com/geofffranks/spruce
 
 #

--- a/ci/scripts/shipit.sh
+++ b/ci/scripts/shipit.sh
@@ -97,15 +97,15 @@ echo ">> Adding all modified files"
 git add -A
 git status
 echo ">> Committing version bump (and any other changes)"
-git commit -m "update release version to v${version}"
+git commit -m "update release version to v${VERSION}"
 git log -n1
 
 
 echo "Preparing Github release"
 mkdir -p ${ROOT}/releases
-cp ${ROOT}/ci/release_notes.md       ${ROOT}/releases/notes.md
-echo "${release_name} v${version}" > ${ROOT}/releases/name
-echo "v${version}"                 > ${ROOT}/releases/tag
+cp ${ROOT}/ci/release_notes.md  ${ROOT}/releases/notes.md
+echo "${RELEASE} v${VERSION}" > ${ROOT}/releases/name
+echo "v${VERSION}"            > ${ROOT}/releases/tag
 
 if [[ "${GOPATH}/src/${PACKAGE}" != "$(pwd)" ]]; then
 	echo ">> Setting up spruce in GOPATH (${GOPATH})"
@@ -117,7 +117,7 @@ fi
 echo ">> Running cross-compiling build (in $(pwd))"
 godep restore
 OUTPUT=${ROOT}/releases IN_RELEASE=yes ./build.sh
-./spruce -v 2>&1 | grep "./spruce - Version ${version} (release)"
+./spruce -v 2>&1 | grep "./spruce - Version ${VERSION} (release)"
 
 echo ">> Github release is ready to go (in ${ROOT}/releases)"
 tree ${ROOT}/releases

--- a/ci/scripts/shipit.sh
+++ b/ci/scripts/shipit.sh
@@ -1,24 +1,83 @@
 #!/bin/bash
-
 set -ex
+PACKAGE=github.com/geofffranks/spruce
 
-# change to root of bosh release
-DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-cd $DIR/../..
+#
+# ci/scripts/shipit.sh - Perform Release Activities for Spruce
+#
+# This script is run from a Concourse pipeline (per ci/pipeline.yml).
+#
+# It is chiefly responsible for:
+#  - bumping the version embedded in main.go,
+#  - committing that change back to the repo (and pushing it),
+#  - cross-compiling spruce for the desired platforms
+#  - copying release notes around
+#  - providing a final 'releases/' directory for use by the
+#    next step in the pipeline (a github-release put)
+#
+#  The structure of 'releases/' directory is:
+#    ${ROOT}/releases/
+#      ├── name
+#      ├── notes.md
+#      ├── spruce-${OS}-${ARCH}*
+#      └── tag
+#
+# Environment Variables
+#   RELEASE - The name of the RELEASE (i.e. "Spruce Release")
+#   VERSION - The version to bump to.  If not set, the version number
+#             *must* be found in the file ${VERSION_FROM} (which must
+#             contain the path to a real, regular file)
+#   BRANCH  - The name of the branch to merge into the checked-out
+#             copy before committing version bump changes.
+#             (defaults to "master")
+#
 
-set -e
+function auto_sed() {
+	cmd=$1
+	shift
 
-version=$(cat ../version/number)
-if [ -z "$version" ]; then
-  echo "missing version number"
-  exit 1
+	if [[ "$(uname -s)" == "Darwin" ]]; then
+		sed -i '' -e "$cmd" $@
+	else
+		sed -i -e "$cmd" $@
+	fi
+}
+
+# change to root of Spruce repository (from ci/scripts)
+ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )
+cd $ROOT
+
+# NB: VERSION_FROM overrides whatever explicit version has been set
+#     in the environment, since only Concourse should be setting VERSION_FROM
+if [[ -z "${VERSION:-}" || -n "${VERSION_FROM:-}" ]]; then
+	if [[ -z "${VERSION_FROM:-}" ]]; then
+		echo >&2 "No VERSION env var specified, and VERSION_FROM is empty or not set"
+		echo >&2 "You need to either set an explicit version via VERSION=<x.y.z>,"
+		echo >&2 "or, point me at a file containing the version via VERSION_FROM=<path>"
+		exit 1
+	fi
+	if [[ ! -f ${VERSION_FROM} ]]; then
+		echo >&2 "No VERSION env var specified, and ${VERSION_FROM} file not found"
+		echo >&2 "  (from cwd $PWD)"
+		exit 1
+	fi
+	VERSION=$(cat ${VERSION_FROM})
+	if [[ -z "${VERSION:-}" ]]; then
+		echo >&2 "VERSION not found in ${VERSION_FROM}"
+		exit 1
+	fi
 fi
-if [[ "${release_name}X" == "X" ]]; then
-  echo "missing \$release_name"
-  exit 1
+
+if [[ -z "${RELEASE:-}" ]]; then
+	RELEASE="Spruce Release"
 fi
 
-sed -i -e "s/var VERSION = \".*\"/var VERSION = \"${version}\"/" main.go
+if [[ -z "${BRANCH:-}" ]]; then
+	BRANCH="master"
+fi
+
+echo ">> Bumping ${RELEASE} to ${VERSION}"
+auto_sed "s/var VERSION = \".*\"/var VERSION = \"${VERSION}\"/" main.go
 
 set +e
 if [[ -z $(git config --global user.email) ]]; then
@@ -29,26 +88,38 @@ if [[ -z $(git config --global user.name) ]]; then
 fi
 set -e
 
-git merge --no-edit ${promotion_branch}
+echo ">> Running git operations as $(git config --global user.name) <$(git config --global user.email)>"
 
+echo ">> Merging ${BRANCH} into checked-out copy before final commit"
+git merge --no-edit ${BRANCH}
+git status
+echo ">> Adding all modified files"
 git add -A
+git status
+echo ">> Committing version bump (and any other changes)"
 git commit -m "update release version to v${version}"
+git log -n1
 
 
-echo Prepare github release information
-set -x
-mkdir -p releases
-cp ci/release_notes.md releases/notes.md
-echo "${release_name} v${version}" > releases/name
-echo "v${version}" > releases/tag
-# Update version
+echo "Preparing Github release"
+mkdir -p ${ROOT}/releases
+cp ${ROOT}/ci/release_notes.md       ${ROOT}/releases/notes.md
+echo "${release_name} v${version}" > ${ROOT}/releases/name
+echo "v${version}"                 > ${ROOT}/releases/tag
 
-cd ../
-mkdir -p $GOPATH/src/github/geofffranks/
-cp -r spruce $GOPATH/src/github/geofffranks/.
-pushd $GOPATH/src/github/geofffranks/spruce
+if [[ "${GOPATH}/src/${PACKAGE}" != "$(pwd)" ]]; then
+	echo ">> Setting up spruce in GOPATH (${GOPATH})"
+	mkdir -p ${GOPATH}/src/${PACKAGE}/
+	cp -r ../spruce ${GOPATH}/src/${PACKAGE%/*}/.
+	cd ${GOPATH}/src/${PACKAGE}
+fi
 
+echo ">> Running cross-compiling build (in $(pwd))"
 godep restore
-
-version=${version} DIR=$DIR IN_RELEASE=yes ./build.sh
+OUTPUT=${ROOT}/releases IN_RELEASE=yes ./build.sh
 ./spruce -v 2>&1 | grep "./spruce - Version ${version} (release)"
+
+echo ">> Github release is ready to go (in ${ROOT}/releases)"
+tree ${ROOT}/releases
+
+# vim:ft=bash


### PR DESCRIPTION
Using gox for cross-compiling instead of goxc gets us:

  - No more tarballs (just binaries in the GH releases)
  - An easier integration with jumpbox scripts
  - Statically-compiled binaries (for Alpine Linux / musl!)

To that end, this commit introduces several changes to the build scripts
(both build.sh and shipit.sh) and the pipeline to support gox.  Some of
these changes are cleanups / clarifications as I found the shipit script
in particular to be difficult to follow.