### PR TITLE
Handle VAULT_SKIP_VERIFY in `(( vault ... ))` calls

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,16 +1,5 @@
 # New Features
 
-- `spruce json` is a new subcommand. It allows you to pipe yaml through spruce
-and get json-compatible output.
-
-# Bug Fixes
-- Fixed the `(( vault ))` operator to honor tokens generated from `vault auth`
-- Fixed the `(( vault ))` operator to handle HTTP redirects from the Vault API
-
-# Miscellaneous
-
-We've updated the CI pipeline to be more awesome. It now generates + uploads
-binaries directly to the release as artifacts, without the silly gzip + version
-number embedding that used to occur. If you have anything that is automatically
-downloading `spruce` from the latest release, it is likely that you will need to
-update your workflow. **(THIS IS A BREAKING CHANGE)**
+- The `(( vault ))` operator now honors the `VAULT_SKIP_VERIFY`
+  environment variable for handling not-so-awesome SSL/TLS
+  certificates on your vault endpoint.

--- a/op_vault.go
+++ b/op_vault.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -126,6 +127,11 @@ func getVaultSecret(secret string, subkey string) (string, error) {
 	DEBUG("  crafting GET %s", url)
 
 	client := &http.Client{
+		Transport:  &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: os.Getenv("VAULT_SKIP_VERIFY") != "",
+			},
+		},
 		CheckRedirect: func (req *http.Request, via []*http.Request) error {
 			if len(via) > 10 {
 				return fmt.Errorf("stopped after 10 redirects")


### PR DESCRIPTION
If `VAULT_SKIP_VERIFY` is set in the environment (i.e. not empty), TLS
certificate verification is *not* performed when talking to the
`$VAULT_ADDR` endpoint.