### PR TITLE
Fix Cursor.Glob aliasing bug

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,5 +1,5 @@
-# New Features
+# Bug Fixes
 
-- The `(( vault ))` operator now honors the `VAULT_SKIP_VERIFY`
-  environment variable for handling not-so-awesome SSL/TLS
-  certificates on your vault endpoint.
+- Fixed Cursor.Glob aliasing bug.  This was a pretty severe bug
+  affecting anyone using multiple static ranges in their network
+  definition.

--- a/cursor.go
+++ b/cursor.go
@@ -211,7 +211,7 @@ func (c *Cursor) Glob(tree interface{}) ([]*Cursor, error) {
 	resolver = func(o interface{}, here, path []string, pos int) ([]interface{}, error) {
 		if pos == len(path) {
 			return []interface{}{
-				&Cursor{Nodes: here},
+				(&Cursor{Nodes: here}).Copy(),
 			}, nil
 		}
 

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -231,6 +231,11 @@ key:
       quantity: 7
     - name: grapes
       quantity: 22
+  simple:
+    list:
+      - first
+      - second
+      - third
 `)
 
 			Convey("handles looking up the empty cursor (root)", func() {
@@ -319,6 +324,18 @@ key:
 				So(l[0].String(), ShouldEqual, "key.list.0.name")
 				So(l[1].String(), ShouldEqual, "key.list.1.name")
 				So(l[2].String(), ShouldEqual, "key.list.2.name")
+			})
+
+			Convey("handles terminal glob position", func() {
+				c, err := ParseCursor("key.simple.list.*")
+				So(err, ShouldBeNil)
+
+				l, err := c.Glob(tree)
+				So(err, ShouldBeNil)
+				So(len(l), ShouldEqual, 3)
+				So(l[0].String(), ShouldEqual, "key.simple.list.0")
+				So(l[1].String(), ShouldEqual, "key.simple.list.1")
+				So(l[2].String(), ShouldEqual, "key.simple.list.2")
 			})
 		})
 	})

--- a/evaluator_test.go
+++ b/evaluator_test.go
@@ -1165,6 +1165,48 @@ properties:
     - 192.168.1.2
 
 
+#############################################  handles static_ip across multiple static ranges
+---
+jobs:
+- name: api_z1
+  instances: 4
+  networks:
+  - name: net1
+    static_ips: (( static_ips 0 1 2 3 ))
+
+networks:
+- name: net1
+  subnets:
+    - static:
+      - 10.0.0.2 - 10.0.0.3      #  2 ips
+      - 10.0.0.90                # +1
+      - 10.0.0.100 - 10.0.0.103  # +4
+
+---
+dataflow:
+- jobs.0.networks.0.static_ips: (( static_ips 0 1 2 3 ))
+
+---
+jobs:
+- name: api_z1
+  instances: 4
+  networks:
+  - name: net1
+    static_ips:
+    - 10.0.0.2
+    - 10.0.0.3
+    - 10.0.0.90
+    - 10.0.0.100
+
+networks:
+- name: net1
+  subnets:
+    - static:
+      - 10.0.0.2 - 10.0.0.3      #  2 ips
+      - 10.0.0.90                # +1
+      - 10.0.0.100 - 10.0.0.103  # +4
+
+
 #########################################  Basic test of (( cartesian-product .... )) operator
 ---
 meta:


### PR DESCRIPTION
Fixes #100

Cursors were being inadvertantly aliased when globbing Kleene-closures
that occurred as the last component at a list.

This caused the `(( static_ips ... ))` operator to fail horribly when
handling  multiple static IP ranges, because it would keep duplicating
the last path and incorrectly generate the pool of IP addresses.  In
effect, this:

    networks:
      - name: net1
        # ...
        static:
          - 10.0.0.5 - 10.0.0.6
          - 10.0.0.8 - 10.0.0.9
          - 10.0.0.100 - 10.0.0.199

    jobs:
      - name: api
        networks:
          - name: net1
            static_ips: (( static_ips 0 ))

would misconstrue the static ranges as:

  - 10.0.0.100 - 10.0.0.199
  - 10.0.0.100 - 10.0.0.199
  - 10.0.0.100 - 10.0.0.199

miscalculate the pool size as 3 * 100, and assign 10.0.0.100 to the job.

This has now been fixed.