### PR TITLE
New `(( keys ... ))` operator

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,5 +1,4 @@
-# Bug Fixes
+# New Features
 
-- Fixed Cursor.Glob aliasing bug.  This was a pretty severe bug
-  affecting anyone using multiple static ranges in their network
-  definition.
+- New `(( keys ... ))` operator for extracting the keys of a map
+  into a list, elsewhere in your manifest.

--- a/op_keys.go
+++ b/op_keys.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+)
+
+// KeysOperator ...
+type KeysOperator struct{}
+
+// Setup ...
+func (KeysOperator) Setup() error {
+	return nil
+}
+
+// Phase ...
+func (KeysOperator) Phase() OperatorPhase {
+	return EvalPhase
+}
+
+// Dependencies ...
+func (KeysOperator) Dependencies(_ *Evaluator, _ []*Expr, _ []*Cursor) []*Cursor {
+	return []*Cursor{}
+}
+
+// Run ...
+func (KeysOperator) Run(ev *Evaluator, args []*Expr) (*Response, error) {
+	DEBUG("running (( keys ... )) operation at $.%s", ev.Here)
+	defer DEBUG("done with (( keys ... )) operation at $%s\n", ev.Here)
+
+	var vals []string
+
+	for i, arg := range args {
+		v, err := arg.Resolve(ev.Tree)
+		if err != nil {
+			DEBUG("     [%d]: resolution failed\n    error: %s", i, err)
+			return nil, err
+		}
+
+		switch v.Type {
+		case Literal:
+			DEBUG("  arg[%d]: found string literal '%s'", i, v.Literal)
+			DEBUG("           (keys operator only handles references to other parts of the YAML tree)")
+			return nil, fmt.Errorf("keys operator only accepts key reference arguments")
+
+		case Reference:
+			DEBUG("  arg[%d]: trying to resolve reference $.%s", i, v.Reference)
+			s, err := v.Reference.Resolve(ev.Tree)
+			if err != nil {
+				DEBUG("     [%d]: resolution failed\n    error: %s", i, err)
+				return nil, fmt.Errorf("Unable to resolve `%s`: %s", v.Reference, err)
+			}
+
+			m, ok := s.(map[interface{}]interface{})
+			if !ok {
+				DEBUG("     [%d]: resolved to something that is not a map.  that is unacceptable.", i)
+				return nil, fmt.Errorf("%s is not a map", v.Reference)
+			}
+			DEBUG("     [%d]: resolved to a map; extracting keys", i)
+			for k := range m {
+				vals = append(vals, k.(string))
+			}
+
+		default:
+			DEBUG("  arg[%d]: I don't know what to do with '%v'", i, arg)
+			return nil, fmt.Errorf("keys operator only accepts key reference arguments")
+		}
+		DEBUG("")
+	}
+
+	switch len(args) {
+	case 0:
+		DEBUG("  no arguments supplied to (( keys ... )) operation.  oops.")
+		return nil, fmt.Errorf("no arguments specified to (( keys ... ))")
+
+	default:
+		sort.Strings(vals)
+		return &Response{
+			Type:  Replace,
+			Value: vals,
+		}, nil
+	}
+}
+
+func init() {
+	RegisterOp("keys", KeysOperator{})
+}


### PR DESCRIPTION
Useful for extracting the keys of a map into a list, elsewhere in your manifest.