### PR TITLE
Allow the (( vault )) operator to handle multiple args

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,7 @@
+# New Features
+
+- The `(( vault ))` operator now allows for multiple arguments.
+  It previously required exactly one argument. Now if given multiple
+  arguments, they are concatenated together, and used as the path
+  to search inside Vault. For example: `(( vault meta.vault_prefix "/key:pass" ))`.
+  One-argument `(( vault ))` calls still behave as they used to.

--- a/vault_test.go
+++ b/vault_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/smallfish/simpleyaml"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/yaml.v2"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -168,17 +168,23 @@ secret: REDACTED
 		RunTests(`
 ################################################  emits sensitive credentials
 ---
-meta: secret/key:test
+meta:
+  prefix: secret
+  key: secret/key:test
 secret: (( vault "secret/hand:shake" ))
 username: (( vault "secret/admin:username" ))
 password: (( vault "secret/admin:password" ))
-key: (( vault $.meta ))
+prefixed: (( vault meta.prefix "/admin:password" ))
+key: (( vault $.meta.key ))
 
 ---
-meta: secret/key:test
+meta:
+  key: secret/key:test
+  prefix: secret
 secret: knock, knock
 username: admin
 password: x12345
+prefixed: x12345
 key: testing
 `)
 
@@ -200,7 +206,7 @@ secret: knock, knock
 		os.Setenv("HOME", "assets/home/svtoken")
 		ioutil.WriteFile("assets/home/svtoken/.svtoken",
 			[]byte("vault: "+mock.URL+"\n"+
-			       "token: sekrit-toekin\n"), 0644)
+				"token: sekrit-toekin\n"), 0644)
 		RunTests(`
 ##############################  retrieves token transparently from ~/.svtoken
 ---
@@ -221,7 +227,7 @@ secret: (( vault ))
 
 ---
 1 error(s) detected:
- - $.secret: vault operator requires exactly one argument
+ - $.secret: vault operator requires at least one argument
 
 #########################################  fails on non-existent reference
 ---


### PR DESCRIPTION
(( vault )) now takes all the arguments it is given, and
concats them together, resolving any references. This allows
templators to do things like `(( vault meta.vault_prefix "/mycreds:passwd" ))`,
pulling in the vault_prefix on a per-environment basis, rather than define
each credential on a per-environment basis.