### PR TITLE
Adding a join feature to Spruce

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ ident: (( concat cluster.name "//" env ))
 
 Which will give you an `ident:` key of "mjolnir/production"
 
-But, what if I have a list of strings that I want in a single line? Like a users list, or similar.
+But what if I have a list of strings that I want as a single line? Like a users list, authorities, or similar.
 Do I have to `concat` that piece by piece? No, you can `join` to concatenate a list into one entry.
 
 ```yml
@@ -217,7 +217,7 @@ properties:
   uaa:
     clients:
       admin:
-        authorities: (( join meta.authorities "," ))
+        authorities: (( join "," meta.authorities ))
 ```
 
 This will give you a concatenated list for `authorities`:

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Which will give you an `ident:` key of "mjolnir/production"
 But, what if I have a list of strings that I want in a single line? Like a users list, or similar.
 Do I have to concat that piece by piece? No, you can `join` to concatinate a list into one entry.
 
-```
+```yml
 meta:
   authorities:
   - password.write

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ ident: (( concat cluster.name "//" env ))
 Which will give you an `ident:` key of "mjolnir/production"
 
 But, what if I have a list of strings that I want in a single line? Like a users list, or similar.
-Do I have to concat that piece by piece? No, you can `join` to concatinate a list into one entry.
+Do I have to `concat` that piece by piece? No, you can `join` to concatenate a list into one entry.
 
 ```yml
 meta:
@@ -220,7 +220,7 @@ properties:
         authorities: (( join meta.authorities "," ))
 ```
 
-This will give you a concatinated list for `authorities`: `password.write,clients.write,clients.read,scim.write`
+This will give you a concatenated list for `authorities`: `password.write,clients.write,clients.read,scim.write`
 
 ## How About Some Examples?
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ ident: (( concat cluster.name "//" env ))
 Which will give you an `ident:` key of "mjolnir/production"
 
 But what if I have a list of strings that I want as a single line? Like a users list, authorities, or similar.
-Do I have to `concat` that piece by piece? No, you can `join` to concatenate a list into one entry.
+Do I have to `concat` that piece by piece? No, you can use `join` to concatenate a list into one entry.
 
 ```yml
 meta:

--- a/README.md
+++ b/README.md
@@ -202,6 +202,26 @@ ident: (( concat cluster.name "//" env ))
 
 Which will give you an `ident:` key of "mjolnir/production"
 
+But, what if I have a list of strings that I want in a single line? Like a users list, or similar.
+Do I have to concat that piece by piece? No, you can `join` to concatinate a list into one entry.
+
+```
+meta:
+  authorities:
+  - password.write
+  - clients.write
+  - clients.read
+  - scim.write
+
+properties:
+  uaa:
+    clients:
+      admin:
+        authorities: (( join meta.authorities "," ))
+```
+
+This will give you a concatinated list for `authorities`: `password.write,clients.write,clients.read,scim.write`
+
 ## How About Some Examples?
 
 <a name="ex-basic"></a>

--- a/README.md
+++ b/README.md
@@ -220,7 +220,14 @@ properties:
         authorities: (( join meta.authorities "," ))
 ```
 
-This will give you a concatenated list for `authorities`: `password.write,clients.write,clients.read,scim.write`
+This will give you a concatenated list for `authorities`:
+```yml
+properties:
+  uaa:
+    clients:
+      admin:
+        authorities: password.write,clients.write,clients.read,scim.write
+```
 
 ## How About Some Examples?
 

--- a/examples/joining/base.yml
+++ b/examples/joining/base.yml
@@ -7,4 +7,4 @@ properties:
         id: admin
         secret: something-from-the-vault
         authorized-grant-types: client_credentials
-        authorities: (( join meta.authorities "," ))
+        authorities: (( join "," meta.authorities meta.additional ))

--- a/examples/joining/base.yml
+++ b/examples/joining/base.yml
@@ -1,0 +1,10 @@
+---
+properties:
+  uaa:
+    clients:
+      admin:
+        scope: uaa.none
+        id: admin
+        secret: something-from-the-vault
+        authorized-grant-types: client_credentials
+        authorities: (( join meta.authorities "," ))

--- a/examples/joining/meta.yml
+++ b/examples/joining/meta.yml
@@ -5,6 +5,8 @@ meta:
   - clients.write
   - clients.read
   - scim.write
+
+  additional:
   - scim.read
   - uaa.admin
   - clients.secret

--- a/examples/joining/meta.yml
+++ b/examples/joining/meta.yml
@@ -1,0 +1,10 @@
+---
+meta:
+  authorities:
+  - password.write
+  - clients.write
+  - clients.read
+  - scim.write
+  - scim.read
+  - uaa.admin
+  - clients.secret

--- a/examples/joining/output.yml
+++ b/examples/joining/output.yml
@@ -1,0 +1,20 @@
+---
+meta:
+  authorities:
+  - password.write
+  - clients.write
+  - clients.read
+  - scim.write
+  - scim.read
+  - uaa.admin
+  - clients.secret
+
+properties:
+  uaa:
+    clients:
+      admin:
+        authorities: password.write,clients.write,clients.read,scim.write,scim.read,uaa.admin,clients.secret
+        authorized-grant-types: client_credentials
+        id: admin
+        scope: uaa.none
+        secret: something-from-the-vault

--- a/examples/joining/output.yml
+++ b/examples/joining/output.yml
@@ -5,6 +5,8 @@ meta:
   - clients.write
   - clients.read
   - scim.write
+
+  additional:
   - scim.read
   - uaa.admin
   - clients.secret

--- a/op_join.go
+++ b/op_join.go
@@ -1,0 +1,113 @@
+package spruce
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jhunt/ansi"
+	"github.com/jhunt/tree"
+
+	. "github.com/geofffranks/spruce/log"
+)
+
+// JoinOperator ...
+type JoinOperator struct{}
+
+// Setup ...
+func (JoinOperator) Setup() error {
+	return nil
+}
+
+// Phase ...
+func (JoinOperator) Phase() OperatorPhase {
+	return EvalPhase
+}
+
+// Dependencies ...
+func (JoinOperator) Dependencies(_ *Evaluator, _ []*Expr, _ []*tree.Cursor) []*tree.Cursor {
+	return []*tree.Cursor{}
+}
+
+// Run ...
+func (JoinOperator) Run(ev *Evaluator, args []*Expr) (*Response, error) {
+	DEBUG("running (( join ... )) operation at $.%s", ev.Here)
+	defer DEBUG("done with (( join ... )) operation at $%s\n", ev.Here)
+
+	if len(args) == 0 {
+		DEBUG("  no arguments supplied to (( join ... )) operation.")
+		return nil, ansi.Errorf("no arguments specified to @c{(( join ... ))}")
+	}
+
+	if len(args) > 2 {
+		DEBUG("  too many arguments supplied to (( join ... )) operation.")
+		return nil, ansi.Errorf("too many arguments supplied to @c{(( join ... ))}")
+	}
+
+	// --- argument #0: list ---
+	var list []string
+
+	ref, err := args[0].Resolve(ev.Tree)
+	if err != nil {
+		DEBUG("     [list]: resolution failed\n    error: %s", err)
+		return nil, err
+	}
+
+	if ref.Type != Reference {
+		DEBUG("     [list]: unsupported type for join operator list argument: '%v'", ref)
+		return nil, fmt.Errorf("join operator only accepts reference argument for the list to be joined")
+	}
+
+	DEBUG("     [list]: trying to resolve reference $.%s", ref.Reference)
+	s, err := ref.Reference.Resolve(ev.Tree)
+	if err != nil {
+		DEBUG("     [list]: resolution failed with error: %s", err)
+		return nil, fmt.Errorf("Unable to resolve `%s`: %s", ref.Reference, err)
+	}
+
+	switch s.(type) {
+	case []interface{}:
+		DEBUG("     [list]: $.%s is a list; good", ref.Reference)
+		for idx, entry := range s.([]interface{}) {
+			if str, ok := entry.(string); ok {
+				list = append(list, str)
+
+			} else {
+				DEBUG("     [list]: entry #%d in list is not a string", idx)
+				return nil, ansi.Errorf("entry #%d in list is not compatible for @c{(( join ... ))}", idx)
+			}
+		}
+
+	default:
+		DEBUG("     [list]: $.%s is not a list", ref.Reference)
+		return nil, ansi.Errorf("referenced argument is not a list for @c{(( join ... ))}")
+	}
+
+	// --- argument #1: seperator ---
+	var seperator string
+
+	sep, err := args[1].Resolve(ev.Tree)
+	if err != nil {
+		DEBUG("     [seperator]: resolution failed\n    error: %s", err)
+		return nil, err
+	}
+
+	if sep.Type != Literal {
+		DEBUG("     [seperator]: unsupported type for join operator seperator argument: '%v'", ref)
+		return nil, fmt.Errorf("join operator only accepts literal argument for the seperator")
+	}
+
+	DEBUG("     [seperator]: list seperator will be: %s", sep)
+	seperator = sep.Literal.(string)
+
+	// --- join ---
+
+	DEBUG("  joined list: %s", strings.Join(list, seperator))
+	return &Response{
+		Type:  Replace,
+		Value: strings.Join(list, seperator),
+	}, nil
+}
+
+func init() {
+	RegisterOp("join", JoinOperator{})
+}


### PR DESCRIPTION
Hey there, working with Spruce we realized that sometimes it would be helpful to gather a list of entries across different input files and eventually join that list into a single line entry, for example for authorities, users, scope, or some other custom property.

So I created a new operator for Spruce which basically wraps around the `join` function of `strings`. Using this operator, you can take a list of string and join them with a separator of your choice.
```yml
---
meta:
  list:
  - entry1
  - entry2

result: (( join meta.list "," ))
```

Including prune, this could be helpful to have readable lists going into Spruce and you end up with the comma-separated list for BOSH.
```yml
result: entry1,entry2
```