### PR TITLE
Insert feature for lists in Spruce

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,14 +86,26 @@ Arrays can be merged in three ways - prepending data, appending data, and comple
   ```yml
   - (( merge on <key> ))
   ```
+
 <br> The first merges using `name` as the key to determine
   like objects in the array elements. The second is used to customize which key to use. See [Merging Arrays of Maps](#mapmerge)
   for an example.
 
-- To insert new elements either after (or before) a specific position of an existing array, you can use `insert` with
+- To insert new elements either after or before a specific position of an existing array, you can use `insert` with
   a hint to the respective insertion point in the target list <br>
 
   ```yml
+  list:
+  - name: nats
+    release: v1
+  - name: consul
+    release: v1
+  - name: postgres
+    release: v1
+  ```
+
+  ```yml
+  list:
   - (( insert after "consul" ))
   - name: new-kid-on-the-block
     release: vNext
@@ -199,7 +211,7 @@ meta:
 that you're used to with [spiff](https://github.com/cloudfoundry-incubator/spiff),
 to specify the offsets in the static IP range for a job's network.
 
-Behind the scenes, there are a couple behavior improvements upon spiff. First,
+Behind the scenes, there are a couple behavior improvements upon spiff. First, 
 since all the merging is done first, then post-processing, there's no need
 to worry about getting the instances + networks defined before `(( static_ips() ))`
 is merged in. Second, the error messaging output should be a lot better to aid in

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Arrays can be merged in three ways - prepending data, appending data, and comple
   - (( merge on <key> ))
   ```
 
-<br> The first merges using `name` as the key to determine
+  <br> The first merges using `name` as the key to determine
   like objects in the array elements. The second is used to customize which key to use. See [Merging Arrays of Maps](#mapmerge)
   for an example.
 
@@ -111,7 +111,7 @@ Arrays can be merged in three ways - prepending data, appending data, and comple
     release: vNext
   ```
 
-  <br> or <br>
+  or <br>
 
   ```yml
   - (( insert after on <key> "<name>" ))

--- a/README.md
+++ b/README.md
@@ -86,10 +86,28 @@ Arrays can be merged in three ways - prepending data, appending data, and comple
   ```yml
   - (( merge on <key> ))
   ```
-
 <br> The first merges using `name` as the key to determine
   like objects in the array elements. The second is used to customize which key to use. See [Merging Arrays of Maps](#mapmerge)
   for an example.
+
+- To insert new elements either after (or before) a specific position of an existing array, you can use `insert` with
+  a hint to the respective insertion point in the target list <br>
+
+  ```yml
+  - (( insert after "consul" ))
+  - name: new-kid-on-the-block
+    release: vNext
+  ```
+
+  <br> or <br>
+
+  ```yml
+  - (( insert after on <key> "<name>" ))
+  - <key>: new-kid-on-the-block
+  ```
+  <br> Just like `merge`, the first `insert` is using `name` as the key to determine the target position in the target array.
+  The second is used to customize which key to use. In any case, instead of `after`, you can also use `before`. This will
+  prepend the entries (relative to the specified insertion point).
 
 - If you don't specify a specific merge strategy, the array will
   be merged automatically; using keys if they exist (i.e. `((
@@ -181,7 +199,7 @@ meta:
 that you're used to with [spiff](https://github.com/cloudfoundry-incubator/spiff),
 to specify the offsets in the static IP range for a job's network.
 
-Behind the scenes, there are a couple behavior improvements upon spiff. First, 
+Behind the scenes, there are a couple behavior improvements upon spiff. First,
 since all the merging is done first, then post-processing, there's no need
 to worry about getting the instances + networks defined before `(( static_ips() ))`
 is merged in. Second, the error messaging output should be a lot better to aid in

--- a/README.md
+++ b/README.md
@@ -95,20 +95,26 @@ Arrays can be merged in three ways - prepending data, appending data, and comple
   a hint to the respective insertion point in the target list <br>
 
   ```yml
-  list:
-  - name: nats
-    release: v1
+  jobs:
   - name: consul
-    release: v1
-  - name: postgres
-    release: v1
+    instances: 1
+  - name: nats
+    instances: 2
+  - name: ccdb
+    instances: 2
+  - name: uaadb
+    instances: 2
+  - name: dea
+    instances: 8
+  - name: api
+    instances: 2
   ```
 
   ```yml
-  list:
-  - (( insert after "consul" ))
-  - name: new-kid-on-the-block
-    release: vNext
+  jobs:
+  - (( insert after "dea" ))
+  - name: dea_v2
+    instances: 2
   ```
 
   or <br>

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Arrays can be merged in three ways - prepending data, appending data, and comple
   or <br>
 
   ```yml
-  - (( insert after on <key> "<name>" ))
+  - (( insert after <key> "<name>" ))
   - <key>: new-kid-on-the-block
   ```
   <br> Just like `merge`, the first `insert` is using `name` as the key to determine the target position in the target array.

--- a/examples/inserting/addon.yml
+++ b/examples/inserting/addon.yml
@@ -1,0 +1,6 @@
+---
+meta:
+  list:
+  - (( insert after "fifth" ))
+  - name: new-kid-on-the-block
+    release: vNext

--- a/examples/inserting/addon.yml
+++ b/examples/inserting/addon.yml
@@ -1,6 +1,5 @@
 ---
-meta:
-  list:
-  - (( insert after "fifth" ))
-  - name: new-kid-on-the-block
-    release: vNext
+jobs:
+- (( insert after "dea" ))
+- name: dea_v2
+  instances: 2

--- a/examples/inserting/main.yml
+++ b/examples/inserting/main.yml
@@ -1,15 +1,14 @@
 ---
-meta:
-  list:
-  - name: first
-    release: v1
-  - name: second
-    release: v1
-  - name: third
-    release: v1
-  - name: fourth
-    release: v1
-  - name: fifth
-    release: v1
-  - name: sixth
-    release: v1
+jobs:
+- name: consul
+  instances: 1
+- name: nats
+  instances: 2
+- name: ccdb
+  instances: 2
+- name: uaadb
+  instances: 2
+- name: dea
+  instances: 8
+- name: api
+  instances: 2

--- a/examples/inserting/main.yml
+++ b/examples/inserting/main.yml
@@ -1,0 +1,15 @@
+---
+meta:
+  list:
+  - name: first
+    release: v1
+  - name: second
+    release: v1
+  - name: third
+    release: v1
+  - name: fourth
+    release: v1
+  - name: fifth
+    release: v1
+  - name: sixth
+    release: v1

--- a/examples/inserting/result.yml
+++ b/examples/inserting/result.yml
@@ -1,17 +1,16 @@
 ---
-meta:
-  list:
-  - name: first
-    release: v1
-  - name: second
-    release: v1
-  - name: third
-    release: v1
-  - name: fourth
-    release: v1
-  - name: fifth
-    release: v1
-  - name: new-kid-on-the-block
-    release: vNext
-  - name: sixth
-    release: v1
+jobs:
+- instances: 1
+  name: consul
+- instances: 2
+  name: nats
+- instances: 2
+  name: ccdb
+- instances: 2
+  name: uaadb
+- instances: 8
+  name: dea
+- instances: 2
+  name: dea_v2
+- instances: 2
+  name: api

--- a/examples/inserting/result.yml
+++ b/examples/inserting/result.yml
@@ -1,0 +1,17 @@
+---
+meta:
+  list:
+  - name: first
+    release: v1
+  - name: second
+    release: v1
+  - name: third
+    release: v1
+  - name: fourth
+    release: v1
+  - name: fifth
+    release: v1
+  - name: new-kid-on-the-block
+    release: vNext
+  - name: sixth
+    release: v1

--- a/merge.go
+++ b/merge.go
@@ -20,7 +20,7 @@ type Merger struct {
 	depth  int
 }
 
-type Foobar struct {
+type InsertSlice struct {
 	index    int
 	relative string
 	key      string
@@ -377,11 +377,11 @@ func shouldInsertIntoArrayBasedOnIndex(obj []interface{}) (bool, int) {
 	return false, -1
 }
 
-func shouldInsertIntoArrayBasedOnName(obj []interface{}) (bool, []Foobar) {
+func shouldInsertIntoArrayBasedOnName(obj []interface{}) (bool, []InsertSlice) {
 	if len(obj) >= 1 && reflect.TypeOf(obj[0]).Kind() == reflect.String {
 		re := regexp.MustCompile("^\\Q((\\E\\s*insert\\s+(after|before)\\s+(on\\s+([^ ]+))?\\s*\"(.+)\"\\s*\\Q))\\E$")
 
-		var result []Foobar
+		var result []InsertSlice
 		for i, entry := range obj {
 			if reflect.TypeOf(entry).Kind() == reflect.String {
 				if re.MatchString(entry.(string)) {
@@ -403,12 +403,12 @@ func shouldInsertIntoArrayBasedOnName(obj []interface{}) (bool, []Foobar) {
 							key = capturedKey
 						}
 
-						foobar := &Foobar{}
-						foobar.index = i
-						foobar.relative = capturedRelative
-						foobar.key = key
-						foobar.name = capturedName
-						result = append(result, *foobar)
+						insertSlice := &InsertSlice{}
+						insertSlice.index = i
+						insertSlice.relative = capturedRelative
+						insertSlice.key = key
+						insertSlice.name = capturedName
+						result = append(result, *insertSlice)
 					}
 				}
 			}

--- a/merge.go
+++ b/merge.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"strconv"
+	"strings"
 
 	"github.com/jhunt/ansi"
 
@@ -163,6 +165,50 @@ func (m *Merger) mergeArray(orig []interface{}, n []interface{}, node string) []
 		}
 
 		return m.mergeArrayByKey(orig, n[1:], node, key)
+
+	} else if should, idx := shouldInsertIntoArrayBasedOnIndex(n); should {
+		if idx < 0 || idx > len(orig) {
+			m.Errors.Append(ansi.Errorf("@m{%s}: @R{specified insertion index} @c{%d} @R{is out of bounds}", node, idx))
+			return nil
+		}
+
+		DEBUG("%s: inserting %d new elements to existing array, at index %d", node, len(n)-1, idx)
+		return append(orig[0:idx], append(n[1:], orig[idx:]...)...)
+
+	} else if should, relative, key, name := shouldInsertIntoArrayBasedOnName(n); should {
+		DEBUG("%s: inserting %d new elements to existing array %s entry '%s: %s'", node, len(n)-1, relative, key, name)
+
+		if err := canKeyMergeArray("new", n[1:], node, key); err != nil {
+			m.Errors.Append(err)
+			return nil
+		}
+
+		if err := canKeyMergeArray("original", orig, node, key); err != nil {
+			m.Errors.Append(err)
+			return nil
+		}
+
+		idx := getIndexOfEntry(orig, key, name)
+		if idx < 0 {
+			m.Errors.Append(ansi.Errorf("@m{%s}: @R{unable to find specified insertion point with} @c{'%s: %s'}", node, key, name))
+			return nil
+		}
+
+		// Since we have a way to identify indiviual entries based on their key/id, we can sanity check for possible duplicates
+		for i, entry := range n[1:] {
+			obj := entry.(map[interface{}]interface{})
+			entryName := obj[key].(string)
+			if getIndexOfEntry(orig, key, entryName) > 0 {
+				m.Errors.Append(ansi.Errorf("@m{%s}: @R{unable to insert, because new list entry} @c{%d} @R{is detected in both lists} @c{'%s: %s'}", node, i, key, entryName))
+				return nil
+			}
+		}
+
+		if relative == "after" {
+			idx++
+		}
+
+		return append(orig[0:idx], append(n[1:], orig[idx:]...)...)
 	}
 
 	DEBUG("%s: performing index-based array merge", node)
@@ -272,6 +318,67 @@ func shouldPrependToArray(obj []interface{}) bool {
 	return false
 }
 
+func shouldInsertIntoArrayBasedOnIndex(obj []interface{}) (bool, int) {
+	if len(obj) >= 1 && reflect.TypeOf(obj[0]).Kind() == reflect.String {
+		re := regexp.MustCompile("^\\Q((\\E\\s*insert\\s+(after|before)\\s+(.+)\\s*\\Q))\\E$")
+		if re.MatchString(obj[0].(string)) {
+			captures := re.FindStringSubmatch(obj[0].(string))
+			relative := strings.TrimSpace(captures[1])
+			position := strings.TrimSpace(captures[2])
+			if idx, err := strconv.Atoi(position); err == nil {
+				// Back out if the index is lower than zero
+				if idx < 0 {
+					return false, -1
+				}
+
+				if relative == "after" {
+					return true, idx + 1
+
+				} else {
+					return true, idx
+				}
+			}
+		}
+	}
+
+	return false, -1
+}
+
+func shouldInsertIntoArrayBasedOnName(obj []interface{}) (bool, string, string, string) {
+	if len(obj) >= 1 && reflect.TypeOf(obj[0]).Kind() == reflect.String {
+		re := regexp.MustCompile("^\\Q((\\E\\s*insert\\s+(after|before)\\s+(on\\s+([^ ]+))?\\s*\"(.+)\"\\s*\\Q))\\E$")
+		if re.MatchString(obj[0].(string)) {
+			captures := re.FindStringSubmatch(obj[0].(string))
+
+			DEBUG("%d", len(captures))
+			for _, entry := range captures {
+				DEBUG("%s", entry)
+			}
+
+      /* #0 is the whole string,
+       * #1 is after or before
+       * #2 contains the optional 'on <key>' string
+       * #3 contains the optional '<key>' string (because of nested capture groups)
+       * #4 is finally the target "<name>" string 
+       */
+			if len(captures) == 5 {
+				capturedRelative := strings.TrimSpace(captures[1])
+				capturedKey := strings.TrimSpace(captures[3])
+				capturedName := strings.TrimSpace(captures[4])
+
+				key := "name"
+				if capturedKey != "" {
+					key = capturedKey
+				}
+
+				return true, capturedRelative, key, capturedName
+			}
+		}
+	}
+
+	return false, "", "", ""
+}
+
 func shouldKeyMergeArray(obj []interface{}) (bool, string) {
 	key := "name"
 
@@ -315,4 +422,17 @@ func shouldReplaceArray(obj []interface{}) bool {
 		}
 	}
 	return false
+}
+
+func getIndexOfEntry(list []interface{}, key string, name string) int {
+	for i, entry := range list {
+		if reflect.TypeOf(entry).Kind() == reflect.Map {
+			obj := entry.(map[interface{}]interface{})
+			if obj[key] == name {
+				return i
+			}
+		}
+	}
+
+	return -1
 }

--- a/merge.go
+++ b/merge.go
@@ -355,12 +355,12 @@ func shouldInsertIntoArrayBasedOnName(obj []interface{}) (bool, string, string, 
 				DEBUG("%s", entry)
 			}
 
-      /* #0 is the whole string,
-       * #1 is after or before
-       * #2 contains the optional 'on <key>' string
-       * #3 contains the optional '<key>' string (because of nested capture groups)
-       * #4 is finally the target "<name>" string 
-       */
+			/* #0 is the whole string,
+			 * #1 is after or before
+			 * #2 contains the optional 'on <key>' string
+			 * #3 contains the optional '<key>' string (because of nested capture groups)
+			 * #4 is finally the target "<name>" string
+			 */
 			if len(captures) == 5 {
 				capturedRelative := strings.TrimSpace(captures[1])
 				capturedKey := strings.TrimSpace(captures[3])

--- a/merge.go
+++ b/merge.go
@@ -207,7 +207,7 @@ func (m *Merger) mergeArray(orig []interface{}, n []interface{}, node string) []
 			}
 
 			// Look up the index of the specified insertion point (based on its key/name)
-			idx := getIndexOfEntry(orig, key, name)
+			idx := getIndexOfEntry(result, key, name)
 			if idx < 0 {
 				m.Errors.Append(ansi.Errorf("@m{%s}: @R{unable to find specified insertion point with} @c{'%s: %s'}", node, key, name))
 				return nil

--- a/merge.go
+++ b/merge.go
@@ -379,7 +379,7 @@ func shouldInsertIntoArrayBasedOnIndex(obj []interface{}) (bool, int) {
 
 func shouldInsertIntoArrayBasedOnName(obj []interface{}) (bool, []InsertSlice) {
 	if len(obj) >= 1 && reflect.TypeOf(obj[0]).Kind() == reflect.String {
-		re := regexp.MustCompile("^\\Q((\\E\\s*insert\\s+(after|before)\\s+(on\\s+([^ ]+))?\\s*\"(.+)\"\\s*\\Q))\\E$")
+		re := regexp.MustCompile("^\\Q((\\E\\s*insert\\s+(after|before)\\s+([^ ]+)?\\s*\"(.+)\"\\s*\\Q))\\E$")
 
 		var result []InsertSlice
 		for i, entry := range obj {
@@ -389,14 +389,13 @@ func shouldInsertIntoArrayBasedOnName(obj []interface{}) (bool, []InsertSlice) {
 
 					/* #0 is the whole string,
 					 * #1 is after or before
-					 * #2 contains the optional 'on <key>' string
-					 * #3 contains the optional '<key>' string (because of nested capture groups)
-					 * #4 is finally the target "<name>" string
+					 * #2 contains the optional '<key>' string
+					 * #3 is finally the target "<name>" string
 					 */
-					if len(captures) == 5 {
+					if len(captures) == 4 {
 						capturedRelative := strings.TrimSpace(captures[1])
-						capturedKey := strings.TrimSpace(captures[3])
-						capturedName := strings.TrimSpace(captures[4])
+						capturedKey := strings.TrimSpace(captures[2])
+						capturedName := strings.TrimSpace(captures[3])
 
 						key := "name"
 						if capturedKey != "" {

--- a/merge.go
+++ b/merge.go
@@ -20,14 +20,6 @@ type Merger struct {
 	depth  int
 }
 
-type InsertSlice struct {
-	index    int
-	relative string
-	key      string
-	name     string
-	list     []interface{}
-}
-
 // Merge ...
 func Merge(l ...map[interface{}]interface{}) (map[interface{}]interface{}, error) {
 	m := &Merger{}
@@ -183,55 +175,40 @@ func (m *Merger) mergeArray(orig []interface{}, n []interface{}, node string) []
 		DEBUG("%s: inserting %d new elements to existing array, at index %d", node, len(n)-1, idx)
 		return append(orig[0:idx], append(n[1:], orig[idx:]...)...)
 
-	} else if should, insertSlices := shouldInsertIntoArrayBasedOnName(n); should {
-		// Create a copy of orig for the (multiple) modifications that are about to happen
-		result := make([]interface{}, len(orig))
-		copy(result, orig)
+	} else if should, relative, key, name := shouldInsertIntoArrayBasedOnName(n); should {
+		DEBUG("%s: inserting %d new elements to existing array %s entry '%s: %s'", node, len(n)-1, relative, key, name)
 
-		for i := range insertSlices {
-			relative := insertSlices[i].relative
-			key := insertSlices[i].key
-			name := insertSlices[i].name
-
-			list := make([]interface{}, len(insertSlices[i].list))
-			copy(list, insertSlices[i].list)
-
-			if err := canKeyMergeArray("original", result, node, key); err != nil {
-				m.Errors.Append(err)
-				return nil
-			}
-
-			if err := canKeyMergeArray("new", list, node, key); err != nil {
-				m.Errors.Append(err)
-				return nil
-			}
-
-			// Look up the index of the specified insertion point (based on its key/name)
-			idx := getIndexOfEntry(result, key, name)
-			if idx < 0 {
-				m.Errors.Append(ansi.Errorf("@m{%s}: @R{unable to find specified insertion point with} @c{'%s: %s'}", node, key, name))
-				return nil
-			}
-
-			// Since we have a way to identify indiviual entries based on their key/id, we can sanity check for possible duplicates
-			for _, entry := range list {
-				obj := entry.(map[interface{}]interface{})
-				entryName := obj[key].(string)
-				if getIndexOfEntry(result, key, entryName) > 0 {
-					m.Errors.Append(ansi.Errorf("@m{%s}: @R{unable to insert, because new list entry} @c{'%s: %s'} @R{is detected multiple times}", node, key, entryName))
-					return nil
-				}
-			}
-
-			if relative == "after" {
-				idx++
-			}
-
-			DEBUG("%s: inserting %d new elements to existing array, %s entry '%s: %s'", node, len(list), relative, key, name)
-			result = insertInto(result, idx, list)
+		if err := canKeyMergeArray("new", n[1:], node, key); err != nil {
+			m.Errors.Append(err)
+			return nil
 		}
 
-		return result
+		if err := canKeyMergeArray("original", orig, node, key); err != nil {
+			m.Errors.Append(err)
+			return nil
+		}
+
+		idx := getIndexOfEntry(orig, key, name)
+		if idx < 0 {
+			m.Errors.Append(ansi.Errorf("@m{%s}: @R{unable to find specified insertion point with} @c{'%s: %s'}", node, key, name))
+			return nil
+		}
+
+		// Since we have a way to identify indiviual entries based on their key/id, we can sanity check for possible duplicates
+		for i, entry := range n[1:] {
+			obj := entry.(map[interface{}]interface{})
+			entryName := obj[key].(string)
+			if getIndexOfEntry(orig, key, entryName) > 0 {
+				m.Errors.Append(ansi.Errorf("@m{%s}: @R{unable to insert, because new list entry} @c{%d} @R{is detected in both lists} @c{'%s: %s'}", node, i, key, entryName))
+				return nil
+			}
+		}
+
+		if relative == "after" {
+			idx++
+		}
+
+		return append(orig[0:idx], append(n[1:], orig[idx:]...)...)
 	}
 
 	DEBUG("%s: performing index-based array merge", node)
@@ -311,16 +288,6 @@ func (m *Merger) mergeArrayByKey(orig []interface{}, n []interface{}, node strin
 	return merged
 }
 
-func insertInto(orig []interface{}, idx int, list []interface{}) []interface{} {
-	prefix := make([]interface{}, idx)
-	copy(prefix, orig[0:idx])
-
-	suffix := make([]interface{}, len(orig)-idx)
-	copy(suffix, orig[idx:])
-
-	return append(prefix, append(list, suffix...)...)
-}
-
 func shouldInlineMergeArray(obj []interface{}) bool {
 	if len(obj) >= 1 && reflect.TypeOf(obj[0]).Kind() == reflect.String {
 		re := regexp.MustCompile("^\\Q((\\E\\s*inline\\s*\\Q))\\E$")
@@ -377,68 +344,33 @@ func shouldInsertIntoArrayBasedOnIndex(obj []interface{}) (bool, int) {
 	return false, -1
 }
 
-func shouldInsertIntoArrayBasedOnName(obj []interface{}) (bool, []InsertSlice) {
+func shouldInsertIntoArrayBasedOnName(obj []interface{}) (bool, string, string, string) {
 	if len(obj) >= 1 && reflect.TypeOf(obj[0]).Kind() == reflect.String {
 		re := regexp.MustCompile("^\\Q((\\E\\s*insert\\s+(after|before)\\s+([^ ]+)?\\s*\"(.+)\"\\s*\\Q))\\E$")
+		if re.MatchString(obj[0].(string)) {
+			captures := re.FindStringSubmatch(obj[0].(string))
 
-		var result []InsertSlice
-		for i, entry := range obj {
-			if reflect.TypeOf(entry).Kind() == reflect.String {
-				if re.MatchString(entry.(string)) {
-					captures := re.FindStringSubmatch(entry.(string))
+			/* #0 is the whole string,
+			 * #1 is after or before
+			 * #2 contains the optional '<key>' string (because of nested capture groups)
+			 * #3 is finally the target "<name>" string
+			 */
+			if len(captures) == 4 {
+				capturedRelative := strings.TrimSpace(captures[1])
+				capturedKey := strings.TrimSpace(captures[2])
+				capturedName := strings.TrimSpace(captures[3])
 
-					/* #0 is the whole string,
-					 * #1 is after or before
-					 * #2 contains the optional '<key>' string
-					 * #3 is finally the target "<name>" string
-					 */
-					if len(captures) == 4 {
-						capturedRelative := strings.TrimSpace(captures[1])
-						capturedKey := strings.TrimSpace(captures[2])
-						capturedName := strings.TrimSpace(captures[3])
-
-						key := "name"
-						if capturedKey != "" {
-							key = capturedKey
-						}
-
-						insertSlice := &InsertSlice{}
-						insertSlice.index = i
-						insertSlice.relative = capturedRelative
-						insertSlice.key = key
-						insertSlice.name = capturedName
-						result = append(result, *insertSlice)
-					}
+				key := "name"
+				if capturedKey != "" {
+					key = capturedKey
 				}
+
+				return true, capturedRelative, key, capturedName
 			}
 		}
-
-		// Back out as soon as possible since there was nothing found
-		if len(result) == 0 {
-			return false, nil
-		}
-
-		for i := range result {
-			next := -1
-			if (i + 1) < len(result) {
-				next = result[i+1].index
-			}
-
-			start := result[i].index + 1
-			end := next
-
-			if end > 0 {
-				result[i].list = obj[start:end]
-
-			} else {
-				result[i].list = obj[start:]
-			}
-		}
-
-		return true, result
 	}
 
-	return false, nil
+	return false, "", "", ""
 }
 
 func shouldKeyMergeArray(obj []interface{}) (bool, string) {

--- a/merge_test.go
+++ b/merge_test.go
@@ -266,7 +266,7 @@ func TestShouldInsertIntoArrayBasedOnName(t *testing.T) {
 		})
 
 		Convey("If insert token with after, key-name and insertion-name was found", func() {
-			result, insertSlices := shouldInsertIntoArrayBasedOnName([]interface{}{"(( insert after on name \"nats\" ))", "stuff"})
+			result, insertSlices := shouldInsertIntoArrayBasedOnName([]interface{}{"(( insert after name \"nats\" ))", "stuff"})
 			So(result, ShouldBeTrue)
 			So(insertSlices, ShouldNotBeNil)
 			So(len(insertSlices), ShouldEqual, 1)
@@ -276,7 +276,7 @@ func TestShouldInsertIntoArrayBasedOnName(t *testing.T) {
 		})
 
 		Convey("If insert token with before, another custom key-name and insertion-name was found", func() {
-			result, insertSlices := shouldInsertIntoArrayBasedOnName([]interface{}{"(( insert before on id \"ccdb\" ))", "stuff"})
+			result, insertSlices := shouldInsertIntoArrayBasedOnName([]interface{}{"(( insert before id \"ccdb\" ))", "stuff"})
 			So(result, ShouldBeTrue)
 			So(insertSlices, ShouldNotBeNil)
 			So(len(insertSlices), ShouldEqual, 1)
@@ -286,7 +286,7 @@ func TestShouldInsertIntoArrayBasedOnName(t *testing.T) {
 		})
 
 		Convey("If insert token with after, key-name and insertion-name was found without additional whitespaces", func() {
-			result, insertSlices := shouldInsertIntoArrayBasedOnName([]interface{}{"((insert after on name \"nats\"))", "stuff"})
+			result, insertSlices := shouldInsertIntoArrayBasedOnName([]interface{}{"((insert after name \"nats\"))", "stuff"})
 			So(result, ShouldBeTrue)
 			So(insertSlices, ShouldNotBeNil)
 			So(len(insertSlices), ShouldEqual, 1)
@@ -296,7 +296,7 @@ func TestShouldInsertIntoArrayBasedOnName(t *testing.T) {
 		})
 
 		Convey("If insert token with after, key-name and insertion-name was found with additional whitespaces", func() {
-			result, insertSlices := shouldInsertIntoArrayBasedOnName([]interface{}{"((   insert   after  on    name   \"nats\"   ))", "stuff"})
+			result, insertSlices := shouldInsertIntoArrayBasedOnName([]interface{}{"((   insert   after     name   \"nats\"   ))", "stuff"})
 			So(result, ShouldBeTrue)
 			So(insertSlices, ShouldNotBeNil)
 			So(len(insertSlices), ShouldEqual, 1)
@@ -306,7 +306,7 @@ func TestShouldInsertIntoArrayBasedOnName(t *testing.T) {
 		})
 
 		Convey("If insert token with after, key-name and insertion-name was found, but the list is empty", func() {
-			result, insertSlices := shouldInsertIntoArrayBasedOnName([]interface{}{"(( insert after on name \"nats\" ))"})
+			result, insertSlices := shouldInsertIntoArrayBasedOnName([]interface{}{"(( insert after name \"nats\" ))"})
 			So(result, ShouldBeTrue)
 			So(insertSlices, ShouldNotBeNil)
 			So(len(insertSlices), ShouldEqual, 1)
@@ -318,11 +318,11 @@ func TestShouldInsertIntoArrayBasedOnName(t *testing.T) {
 
 		Convey("If there are multiple insert token with after/before, different key names, and names (only technical usecase)", func() {
 			result, insertSlices := shouldInsertIntoArrayBasedOnName([]interface{}{
-				"(( insert after on name \"nats\" ))",
+				"(( insert after name \"nats\" ))",
 				"stuff1",
 				"stuff2",
 				"stuff3",
-				"(( insert before on id \"consul\" ))",
+				"(( insert before id \"consul\" ))",
 				"stuffX1",
 				"stuffX2",
 			})
@@ -1086,7 +1086,7 @@ func TestMergeArray(t *testing.T) {
 				}
 
 				array := []interface{}{
-					"(( insert after on id \"second\" ))",
+					"(( insert after id \"second\" ))",
 					map[interface{}]interface{}{"id": "new-kid-on-the-block", "release": "vNext"},
 				}
 
@@ -1110,7 +1110,7 @@ func TestMergeArray(t *testing.T) {
 				}
 
 				array := []interface{}{
-					"(( insert before on id \"second\" ))",
+					"(( insert before id \"second\" ))",
 					map[interface{}]interface{}{"id": "new-kid-on-the-block", "release": "vNext"},
 				}
 
@@ -1134,10 +1134,10 @@ func TestMergeArray(t *testing.T) {
 				}
 
 				array := []interface{}{
-					"(( insert before on id \"second\" ))",
+					"(( insert before id \"second\" ))",
 					map[interface{}]interface{}{"id": "new-kid-on-the-block-1", "release": "vNext"},
 					map[interface{}]interface{}{"id": "new-kid-on-the-block-2", "release": "vNext"},
-					"(( insert after on id \"first\" ))",
+					"(( insert after id \"first\" ))",
 					map[interface{}]interface{}{"id": "new-kid-on-the-block-3", "release": "vNext"},
 					map[interface{}]interface{}{"id": "new-kid-on-the-block-4", "release": "vNext"},
 				}
@@ -1165,10 +1165,10 @@ func TestMergeArray(t *testing.T) {
 				}
 
 				array := []interface{}{
-					"(( insert after on id \"first\" ))",
+					"(( insert after id \"first\" ))",
 					map[interface{}]interface{}{"id": "new-kid-on-the-block-1", "release": "vNext"},
 					map[interface{}]interface{}{"id": "new-kid-on-the-block-2", "release": "vNext"},
-					"(( insert after on id \"first\" ))",
+					"(( insert after id \"first\" ))",
 					map[interface{}]interface{}{"id": "new-kid-on-the-block-3", "release": "vNext"},
 					map[interface{}]interface{}{"id": "new-kid-on-the-block-4", "release": "vNext"},
 				}
@@ -1196,13 +1196,13 @@ func TestMergeArray(t *testing.T) {
 				}
 
 				array := []interface{}{
-					"(( insert after on id \"first\" ))",
+					"(( insert after id \"first\" ))",
 					map[interface{}]interface{}{"id": "new-kid-on-the-block-1", "release": "vNext"},
 					map[interface{}]interface{}{"id": "new-kid-on-the-block-2", "release": "vNext"},
-					"(( insert after on id \"first\" ))",
+					"(( insert after id \"first\" ))",
 					map[interface{}]interface{}{"id": "new-kid-on-the-block-3", "release": "vNext"},
 					map[interface{}]interface{}{"id": "new-kid-on-the-block-4", "release": "vNext"},
-					"(( insert after on id \"first\" ))",
+					"(( insert after id \"first\" ))",
 					map[interface{}]interface{}{"id": "new-kid-on-the-block-5", "release": "vNext"},
 					map[interface{}]interface{}{"id": "new-kid-on-the-block-6", "release": "vNext"},
 				}
@@ -1232,7 +1232,7 @@ func TestMergeArray(t *testing.T) {
 				}
 
 				array := []interface{}{
-					"(( insert after on name \"not-existing\" ))",
+					"(( insert after name \"not-existing\" ))",
 					map[interface{}]interface{}{"name": "new-kid-on-the-block", "release": "vNext"},
 				}
 
@@ -1251,7 +1251,7 @@ func TestMergeArray(t *testing.T) {
 				}
 
 				array := []interface{}{
-					"(( insert after on id \"second\" ))",
+					"(( insert after id \"second\" ))",
 					map[interface{}]interface{}{"name": "new-kid-on-the-block", "release": "vNext"},
 				}
 
@@ -1270,7 +1270,7 @@ func TestMergeArray(t *testing.T) {
 				}
 
 				array := []interface{}{
-					"(( insert after on id \"second\" ))",
+					"(( insert after id \"second\" ))",
 					map[interface{}]interface{}{"id": "new-kid-on-the-block", "release": "vNext"},
 				}
 
@@ -1289,7 +1289,7 @@ func TestMergeArray(t *testing.T) {
 				}
 
 				array := []interface{}{
-					"(( insert after on name \"second\" ))",
+					"(( insert after name \"second\" ))",
 					map[interface{}]interface{}{"name": "new-kid-on-the-block", "release": "vNext"},
 					map[interface{}]interface{}{"name": "second", "release": "vNext"},
 				}

--- a/merge_test.go
+++ b/merge_test.go
@@ -1225,6 +1225,48 @@ func TestMergeArray(t *testing.T) {
 				So(err, ShouldBeNil)
 			})
 
+			Convey("Insert multiple new entries in different batches which will insert", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{"id": "first", "release": "v1"},
+					map[interface{}]interface{}{"id": "second", "release": "v1"},
+					map[interface{}]interface{}{"id": "third", "release": "v1"},
+					map[interface{}]interface{}{"id": "fourth", "release": "v1"},
+					map[interface{}]interface{}{"id": "fifth", "release": "v1"},
+					map[interface{}]interface{}{"id": "sixth", "release": "v1"},
+					map[interface{}]interface{}{"id": "seventh", "release": "v1"},
+					map[interface{}]interface{}{"id": "eighth", "release": "v1"},
+				}
+
+				array := []interface{}{
+					"(( insert after id \"second\" ))",
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-1", "release": "vNext"},
+					"(( insert after id \"fourth\" ))",
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-2", "release": "vNext"},
+					"(( insert after id \"sixth\" ))",
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-3", "release": "vNext"},
+				}
+
+				expect := []interface{}{
+					map[interface{}]interface{}{"id": "first", "release": "v1"},
+					map[interface{}]interface{}{"id": "second", "release": "v1"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-1", "release": "vNext"},
+					map[interface{}]interface{}{"id": "third", "release": "v1"},
+					map[interface{}]interface{}{"id": "fourth", "release": "v1"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-2", "release": "vNext"},
+					map[interface{}]interface{}{"id": "fifth", "release": "v1"},
+					map[interface{}]interface{}{"id": "sixth", "release": "v1"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-3", "release": "vNext"},
+					map[interface{}]interface{}{"id": "seventh", "release": "v1"},
+					map[interface{}]interface{}{"id": "eighth", "release": "v1"},
+				}
+
+				m := &Merger{}
+				a := m.mergeArray(orig, array, "node-path")
+				err := m.Error()
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
+			})
+
 			Convey("throw an error when insertion point cannot be found", func() {
 				orig := []interface{}{
 					map[interface{}]interface{}{"name": "first", "release": "v1"},

--- a/merge_test.go
+++ b/merge_test.go
@@ -256,93 +256,51 @@ func TestShouldInsertIntoArrayBasedOnIndex(t *testing.T) {
 func TestShouldInsertIntoArrayBasedOnName(t *testing.T) {
 	Convey("We should insert into arrays based on key and name", t, func() {
 		Convey("If insert token with after, and insertion-name was found", func() {
-			result, insertSlices := shouldInsertIntoArrayBasedOnName([]interface{}{"(( insert after \"nats\" ))", "stuff"})
+			result, relative, key, name := shouldInsertIntoArrayBasedOnName([]interface{}{"(( insert after \"nats\" ))", "stuff"})
 			So(result, ShouldBeTrue)
-			So(insertSlices, ShouldNotBeNil)
-			So(len(insertSlices), ShouldEqual, 1)
-			So(insertSlices[0].relative, ShouldEqual, "after")
-			So(insertSlices[0].key, ShouldEqual, "name")
-			So(insertSlices[0].name, ShouldEqual, "nats")
+			So(relative, ShouldEqual, "after")
+			So(key, ShouldEqual, "name")
+			So(name, ShouldEqual, "nats")
 		})
 
 		Convey("If insert token with after, key-name and insertion-name was found", func() {
-			result, insertSlices := shouldInsertIntoArrayBasedOnName([]interface{}{"(( insert after name \"nats\" ))", "stuff"})
+			result, relative, key, name := shouldInsertIntoArrayBasedOnName([]interface{}{"(( insert after name \"nats\" ))", "stuff"})
 			So(result, ShouldBeTrue)
-			So(insertSlices, ShouldNotBeNil)
-			So(len(insertSlices), ShouldEqual, 1)
-			So(insertSlices[0].relative, ShouldEqual, "after")
-			So(insertSlices[0].key, ShouldEqual, "name")
-			So(insertSlices[0].name, ShouldEqual, "nats")
+			So(relative, ShouldEqual, "after")
+			So(key, ShouldEqual, "name")
+			So(name, ShouldEqual, "nats")
 		})
 
 		Convey("If insert token with before, another custom key-name and insertion-name was found", func() {
-			result, insertSlices := shouldInsertIntoArrayBasedOnName([]interface{}{"(( insert before id \"ccdb\" ))", "stuff"})
+			result, relative, key, name := shouldInsertIntoArrayBasedOnName([]interface{}{"(( insert before id \"ccdb\" ))", "stuff"})
 			So(result, ShouldBeTrue)
-			So(insertSlices, ShouldNotBeNil)
-			So(len(insertSlices), ShouldEqual, 1)
-			So(insertSlices[0].relative, ShouldEqual, "before")
-			So(insertSlices[0].key, ShouldEqual, "id")
-			So(insertSlices[0].name, ShouldEqual, "ccdb")
+			So(relative, ShouldEqual, "before")
+			So(key, ShouldEqual, "id")
+			So(name, ShouldEqual, "ccdb")
 		})
 
 		Convey("If insert token with after, key-name and insertion-name was found without additional whitespaces", func() {
-			result, insertSlices := shouldInsertIntoArrayBasedOnName([]interface{}{"((insert after name \"nats\"))", "stuff"})
+			result, relative, key, name := shouldInsertIntoArrayBasedOnName([]interface{}{"((insert after name \"nats\"))", "stuff"})
 			So(result, ShouldBeTrue)
-			So(insertSlices, ShouldNotBeNil)
-			So(len(insertSlices), ShouldEqual, 1)
-			So(insertSlices[0].relative, ShouldEqual, "after")
-			So(insertSlices[0].key, ShouldEqual, "name")
-			So(insertSlices[0].name, ShouldEqual, "nats")
+			So(relative, ShouldEqual, "after")
+			So(key, ShouldEqual, "name")
+			So(name, ShouldEqual, "nats")
 		})
 
 		Convey("If insert token with after, key-name and insertion-name was found with additional whitespaces", func() {
-			result, insertSlices := shouldInsertIntoArrayBasedOnName([]interface{}{"((   insert   after     name   \"nats\"   ))", "stuff"})
+			result, relative, key, name := shouldInsertIntoArrayBasedOnName([]interface{}{"((   insert   after   name   \"nats\"   ))", "stuff"})
 			So(result, ShouldBeTrue)
-			So(insertSlices, ShouldNotBeNil)
-			So(len(insertSlices), ShouldEqual, 1)
-			So(insertSlices[0].relative, ShouldEqual, "after")
-			So(insertSlices[0].key, ShouldEqual, "name")
-			So(insertSlices[0].name, ShouldEqual, "nats")
-		})
-
-		Convey("If insert token with after, key-name and insertion-name was found, but the list is empty", func() {
-			result, insertSlices := shouldInsertIntoArrayBasedOnName([]interface{}{"(( insert after name \"nats\" ))"})
-			So(result, ShouldBeTrue)
-			So(insertSlices, ShouldNotBeNil)
-			So(len(insertSlices), ShouldEqual, 1)
-			So(insertSlices[0].relative, ShouldEqual, "after")
-			So(insertSlices[0].key, ShouldEqual, "name")
-			So(insertSlices[0].name, ShouldEqual, "nats")
-			So(insertSlices[0].list, ShouldResemble, []interface{}{})
-		})
-
-		Convey("If there are multiple insert token with after/before, different key names, and names (only technical usecase)", func() {
-			result, insertSlices := shouldInsertIntoArrayBasedOnName([]interface{}{
-				"(( insert after name \"nats\" ))",
-				"stuff1",
-				"stuff2",
-				"stuff3",
-				"(( insert before id \"consul\" ))",
-				"stuffX1",
-				"stuffX2",
-			})
-			So(result, ShouldBeTrue)
-			So(insertSlices, ShouldNotBeNil)
-			So(len(insertSlices), ShouldEqual, 2)
-			So(insertSlices[0].relative, ShouldEqual, "after")
-			So(insertSlices[0].key, ShouldEqual, "name")
-			So(insertSlices[0].name, ShouldEqual, "nats")
-			So(insertSlices[0].list, ShouldResemble, []interface{}{"stuff1", "stuff2", "stuff3"})
-			So(insertSlices[1].relative, ShouldEqual, "before")
-			So(insertSlices[1].key, ShouldEqual, "id")
-			So(insertSlices[1].name, ShouldEqual, "consul")
-			So(insertSlices[1].list, ShouldResemble, []interface{}{"stuffX1", "stuffX2"})
+			So(relative, ShouldEqual, "after")
+			So(key, ShouldEqual, "name")
+			So(name, ShouldEqual, "nats")
 		})
 
 		Convey("But not if the magic token is not specified", func() {
-			result, insertSlices := shouldInsertIntoArrayBasedOnName([]interface{}{"not a magic token", "stuff"})
+			result, relative, key, name := shouldInsertIntoArrayBasedOnName([]interface{}{"not a magic token", "stuff"})
 			So(result, ShouldBeFalse)
-			So(insertSlices, ShouldBeNil)
+			So(relative, ShouldEqual, "")
+			So(key, ShouldEqual, "")
+			So(name, ShouldEqual, "")
 		})
 	})
 }
@@ -1127,146 +1085,6 @@ func TestMergeArray(t *testing.T) {
 				So(err, ShouldBeNil)
 			})
 
-			Convey("Insert multiple new entries before second and after first", func() {
-				orig := []interface{}{
-					map[interface{}]interface{}{"id": "first", "release": "v1"},
-					map[interface{}]interface{}{"id": "second", "release": "v1"},
-				}
-
-				array := []interface{}{
-					"(( insert before id \"second\" ))",
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-1", "release": "vNext"},
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-2", "release": "vNext"},
-					"(( insert after id \"first\" ))",
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-3", "release": "vNext"},
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-4", "release": "vNext"},
-				}
-
-				expect := []interface{}{
-					map[interface{}]interface{}{"id": "first", "release": "v1"},
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-3", "release": "vNext"},
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-4", "release": "vNext"},
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-1", "release": "vNext"},
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-2", "release": "vNext"},
-					map[interface{}]interface{}{"id": "second", "release": "v1"},
-				}
-
-				m := &Merger{}
-				a := m.mergeArray(orig, array, "node-path")
-				err := m.Error()
-				So(a, ShouldResemble, expect)
-				So(err, ShouldBeNil)
-			})
-
-			Convey("Insert multiple new entries in two batches after first", func() {
-				orig := []interface{}{
-					map[interface{}]interface{}{"id": "first", "release": "v1"},
-					map[interface{}]interface{}{"id": "second", "release": "v1"},
-				}
-
-				array := []interface{}{
-					"(( insert after id \"first\" ))",
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-1", "release": "vNext"},
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-2", "release": "vNext"},
-					"(( insert after id \"first\" ))",
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-3", "release": "vNext"},
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-4", "release": "vNext"},
-				}
-
-				expect := []interface{}{
-					map[interface{}]interface{}{"id": "first", "release": "v1"},
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-3", "release": "vNext"},
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-4", "release": "vNext"},
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-1", "release": "vNext"},
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-2", "release": "vNext"},
-					map[interface{}]interface{}{"id": "second", "release": "v1"},
-				}
-
-				m := &Merger{}
-				a := m.mergeArray(orig, array, "node-path")
-				err := m.Error()
-				So(a, ShouldResemble, expect)
-				So(err, ShouldBeNil)
-			})
-
-			Convey("Insert multiple new entries in three batches after first", func() {
-				orig := []interface{}{
-					map[interface{}]interface{}{"id": "first", "release": "v1"},
-					map[interface{}]interface{}{"id": "second", "release": "v1"},
-				}
-
-				array := []interface{}{
-					"(( insert after id \"first\" ))",
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-1", "release": "vNext"},
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-2", "release": "vNext"},
-					"(( insert after id \"first\" ))",
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-3", "release": "vNext"},
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-4", "release": "vNext"},
-					"(( insert after id \"first\" ))",
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-5", "release": "vNext"},
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-6", "release": "vNext"},
-				}
-
-				expect := []interface{}{
-					map[interface{}]interface{}{"id": "first", "release": "v1"},
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-5", "release": "vNext"},
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-6", "release": "vNext"},
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-3", "release": "vNext"},
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-4", "release": "vNext"},
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-1", "release": "vNext"},
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-2", "release": "vNext"},
-					map[interface{}]interface{}{"id": "second", "release": "v1"},
-				}
-
-				m := &Merger{}
-				a := m.mergeArray(orig, array, "node-path")
-				err := m.Error()
-				So(a, ShouldResemble, expect)
-				So(err, ShouldBeNil)
-			})
-
-			Convey("Insert multiple new entries in different batches which will insert", func() {
-				orig := []interface{}{
-					map[interface{}]interface{}{"id": "first", "release": "v1"},
-					map[interface{}]interface{}{"id": "second", "release": "v1"},
-					map[interface{}]interface{}{"id": "third", "release": "v1"},
-					map[interface{}]interface{}{"id": "fourth", "release": "v1"},
-					map[interface{}]interface{}{"id": "fifth", "release": "v1"},
-					map[interface{}]interface{}{"id": "sixth", "release": "v1"},
-					map[interface{}]interface{}{"id": "seventh", "release": "v1"},
-					map[interface{}]interface{}{"id": "eighth", "release": "v1"},
-				}
-
-				array := []interface{}{
-					"(( insert after id \"second\" ))",
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-1", "release": "vNext"},
-					"(( insert after id \"fourth\" ))",
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-2", "release": "vNext"},
-					"(( insert after id \"sixth\" ))",
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-3", "release": "vNext"},
-				}
-
-				expect := []interface{}{
-					map[interface{}]interface{}{"id": "first", "release": "v1"},
-					map[interface{}]interface{}{"id": "second", "release": "v1"},
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-1", "release": "vNext"},
-					map[interface{}]interface{}{"id": "third", "release": "v1"},
-					map[interface{}]interface{}{"id": "fourth", "release": "v1"},
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-2", "release": "vNext"},
-					map[interface{}]interface{}{"id": "fifth", "release": "v1"},
-					map[interface{}]interface{}{"id": "sixth", "release": "v1"},
-					map[interface{}]interface{}{"id": "new-kid-on-the-block-3", "release": "vNext"},
-					map[interface{}]interface{}{"id": "seventh", "release": "v1"},
-					map[interface{}]interface{}{"id": "eighth", "release": "v1"},
-				}
-
-				m := &Merger{}
-				a := m.mergeArray(orig, array, "node-path")
-				err := m.Error()
-				So(a, ShouldResemble, expect)
-				So(err, ShouldBeNil)
-			})
-
 			Convey("throw an error when insertion point cannot be found", func() {
 				orig := []interface{}{
 					map[interface{}]interface{}{"name": "first", "release": "v1"},
@@ -1341,7 +1159,7 @@ func TestMergeArray(t *testing.T) {
 				err := m.Error()
 				So(a, ShouldBeNil)
 				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldContainSubstring, "because new list entry 'name: second' is detected multiple times")
+				So(err.Error(), ShouldContainSubstring, "because new list entry 1 is detected in both lists")
 			})
 		})
 	})

--- a/merge_test.go
+++ b/merge_test.go
@@ -201,6 +201,110 @@ func TestShouldKeyMergeArrayOfHashes(t *testing.T) {
 	})
 }
 
+func TestShouldInsertIntoArrayBasedOnIndex(t *testing.T) {
+	Convey("We should insert into arrays based on index", t, func() {
+		Convey("If insert token with after and index is found", func() {
+			result, idx := shouldInsertIntoArrayBasedOnIndex([]interface{}{"(( insert after 0 ))", "stuff"})
+			So(result, ShouldBeTrue)
+			So(idx, ShouldEqual, 1)
+		})
+
+		Convey("If insert token with before and index is found", func() {
+			result, idx := shouldInsertIntoArrayBasedOnIndex([]interface{}{"(( insert before 0 ))", "stuff"})
+			So(result, ShouldBeTrue)
+			So(idx, ShouldEqual, 0)
+		})
+
+		Convey("If insert token with after and index is found independent of missing whitespaces", func() {
+			result, idx := shouldInsertIntoArrayBasedOnIndex([]interface{}{"((insert after 0))", "stuff"})
+			So(result, ShouldBeTrue)
+			So(idx, ShouldEqual, 1)
+		})
+
+		Convey("If insert token with after and index is found with a lot of additional whitespaces", func() {
+			result, idx := shouldInsertIntoArrayBasedOnIndex([]interface{}{"((  insert   after   0  ))", "stuff"})
+			So(result, ShouldBeTrue)
+			So(idx, ShouldEqual, 1)
+		})
+
+		Convey("But not if index is obviously out of bounds", func() {
+			result, idx := shouldInsertIntoArrayBasedOnIndex([]interface{}{"(( insert before -1 ))", "stuff"})
+			So(result, ShouldBeFalse)
+			So(idx, ShouldEqual, -1)
+		})
+
+		Convey("But not if the magic token is not specified", func() {
+			result, idx := shouldInsertIntoArrayBasedOnIndex([]interface{}{"not a magic token", "stuff"})
+			So(result, ShouldBeFalse)
+			So(idx, ShouldEqual, -1)
+		})
+
+		Convey("But not if the index is somehow quoted (and therefore not integer)", func() {
+			result, idx := shouldInsertIntoArrayBasedOnIndex([]interface{}{"(( insert after \"0\" ))", "stuff"})
+			So(result, ShouldBeFalse)
+			So(idx, ShouldEqual, -1)
+		})
+
+		Convey("But not if there is actually a different type of position style is wanted", func() {
+			result, idx := shouldInsertIntoArrayBasedOnIndex([]interface{}{"(( insert after \"foobar\" ))", "stuff"})
+			So(result, ShouldBeFalse)
+			So(idx, ShouldEqual, -1)
+		})
+	})
+}
+
+func TestShouldInsertIntoArrayBasedOnName(t *testing.T) {
+	Convey("We should insert into arrays based on key and name", t, func() {
+		Convey("If insert token with after, and insertion-name was found", func() {
+			result, relative, key, name := shouldInsertIntoArrayBasedOnName([]interface{}{"(( insert after \"nats\" ))", "stuff"})
+			So(result, ShouldBeTrue)
+			So(relative, ShouldEqual, "after")
+			So(key, ShouldEqual, "name")
+			So(name, ShouldEqual, "nats")
+		})
+
+		Convey("If insert token with after, key-name and insertion-name was found", func() {
+			result, relative, key, name := shouldInsertIntoArrayBasedOnName([]interface{}{"(( insert after on name \"nats\" ))", "stuff"})
+			So(result, ShouldBeTrue)
+			So(relative, ShouldEqual, "after")
+			So(key, ShouldEqual, "name")
+			So(name, ShouldEqual, "nats")
+		})
+
+		Convey("If insert token with before, another custom key-name and insertion-name was found", func() {
+			result, relative, key, name := shouldInsertIntoArrayBasedOnName([]interface{}{"(( insert before on id \"ccdb\" ))", "stuff"})
+			So(result, ShouldBeTrue)
+			So(relative, ShouldEqual, "before")
+			So(key, ShouldEqual, "id")
+			So(name, ShouldEqual, "ccdb")
+		})
+
+		Convey("If insert token with after, key-name and insertion-name was found without additional whitespaces", func() {
+			result, relative, key, name := shouldInsertIntoArrayBasedOnName([]interface{}{"((insert after on name \"nats\"))", "stuff"})
+			So(result, ShouldBeTrue)
+			So(relative, ShouldEqual, "after")
+			So(key, ShouldEqual, "name")
+			So(name, ShouldEqual, "nats")
+		})
+
+		Convey("If insert token with after, key-name and insertion-name was found with additional whitespaces", func() {
+			result, relative, key, name := shouldInsertIntoArrayBasedOnName([]interface{}{"((   insert   after  on    name   \"nats\"   ))", "stuff"})
+			So(result, ShouldBeTrue)
+			So(relative, ShouldEqual, "after")
+			So(key, ShouldEqual, "name")
+			So(name, ShouldEqual, "nats")
+		})
+
+		Convey("But not if the magic token is not specified", func() {
+			result, relative, key, name := shouldInsertIntoArrayBasedOnName([]interface{}{"not a magic token", "stuff"})
+			So(result, ShouldBeFalse)
+			So(relative, ShouldEqual, "")
+			So(key, ShouldEqual, "")
+			So(name, ShouldEqual, "")
+		})
+	})
+}
+
 func TestMergeObj(t *testing.T) {
 	Convey("Passing a map to m.mergeObj merges as a map", t, func() {
 		Convey("merges as a map under normal conditions", func() {
@@ -822,6 +926,241 @@ func TestMergeArray(t *testing.T) {
 			err := m.Error()
 			So(o, ShouldResemble, expect)
 			So(err, ShouldBeNil)
+		})
+
+		Convey("with element '(( insert ))' inserts new data where wanted", func() {
+			Convey("After #0 put the new entry", func() {
+				orig := []interface{}{"first", "second", "third", "fourth", "fifth", "sixth"}
+				array := []interface{}{"(( insert after 0 ))", "new-kid-on-the-block"}
+				expect := []interface{}{"first", "new-kid-on-the-block", "second", "third", "fourth", "fifth", "sixth"}
+
+				m := &Merger{}
+				a := m.mergeArray(orig, array, "node-path")
+				err := m.Error()
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Before #0 put the new entry", func() {
+				orig := []interface{}{"first", "second", "third", "fourth", "fifth", "sixth"}
+				array := []interface{}{"(( insert before 0 ))", "new-kid-on-the-block"}
+				expect := []interface{}{"new-kid-on-the-block", "first", "second", "third", "fourth", "fifth", "sixth"}
+
+				m := &Merger{}
+				a := m.mergeArray(orig, array, "node-path")
+				err := m.Error()
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
+			})
+
+			Convey("After #4 put the new entry", func() {
+				orig := []interface{}{"first", "second", "third", "fourth", "fifth", "sixth"}
+				array := []interface{}{"(( insert after 4 ))", "new-kid-on-the-block"}
+				expect := []interface{}{"first", "second", "third", "fourth", "fifth", "new-kid-on-the-block", "sixth"}
+
+				m := &Merger{}
+				a := m.mergeArray(orig, array, "node-path")
+				err := m.Error()
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
+			})
+
+			Convey("After #5 put the new entry", func() {
+				orig := []interface{}{"first", "second", "third", "fourth", "fifth", "sixth"}
+				array := []interface{}{"(( insert after 5 ))", "new-kid-on-the-block"}
+				expect := []interface{}{"first", "second", "third", "fourth", "fifth", "sixth", "new-kid-on-the-block"}
+
+				m := &Merger{}
+				a := m.mergeArray(orig, array, "node-path")
+				err := m.Error()
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
+			})
+
+			Convey("throw an error if insertion point is out of bounds", func() {
+				orig := []interface{}{"first", "second", "third", "fourth", "fifth", "sixth"}
+				array := []interface{}{"(( insert after 6 ))", "new-kid-on-the-block"}
+
+				m := &Merger{}
+				a := m.mergeArray(orig, array, "node-path")
+				err := m.Error()
+				So(a, ShouldBeNil)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "specified insertion index 7 is out of bounds")
+			})
+
+			Convey("After '<default>: first' put the new entry", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{"name": "first", "release": "v1"},
+					map[interface{}]interface{}{"name": "second", "release": "v1"},
+				}
+
+				array := []interface{}{
+					"(( insert after \"first\" ))",
+					map[interface{}]interface{}{"name": "new-kid-on-the-block", "release": "vNext"},
+				}
+
+				expect := []interface{}{
+					map[interface{}]interface{}{"name": "first", "release": "v1"},
+					map[interface{}]interface{}{"name": "new-kid-on-the-block", "release": "vNext"},
+					map[interface{}]interface{}{"name": "second", "release": "v1"},
+				}
+
+				m := &Merger{}
+				a := m.mergeArray(orig, array, "node-path")
+				err := m.Error()
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Before '<default>: first' put the new entry", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{"name": "first", "release": "v1"},
+					map[interface{}]interface{}{"name": "second", "release": "v1"},
+				}
+
+				array := []interface{}{
+					"(( insert before \"first\" ))",
+					map[interface{}]interface{}{"name": "new-kid-on-the-block", "release": "vNext"},
+				}
+
+				expect := []interface{}{
+					map[interface{}]interface{}{"name": "new-kid-on-the-block", "release": "vNext"},
+					map[interface{}]interface{}{"name": "first", "release": "v1"},
+					map[interface{}]interface{}{"name": "second", "release": "v1"},
+				}
+
+				m := &Merger{}
+				a := m.mergeArray(orig, array, "node-path")
+				err := m.Error()
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
+			})
+
+			Convey("After 'id: second' put the new entry", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{"id": "first", "release": "v1"},
+					map[interface{}]interface{}{"id": "second", "release": "v1"},
+				}
+
+				array := []interface{}{
+					"(( insert after on id \"second\" ))",
+					map[interface{}]interface{}{"id": "new-kid-on-the-block", "release": "vNext"},
+				}
+
+				expect := []interface{}{
+					map[interface{}]interface{}{"id": "first", "release": "v1"},
+					map[interface{}]interface{}{"id": "second", "release": "v1"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block", "release": "vNext"},
+				}
+
+				m := &Merger{}
+				a := m.mergeArray(orig, array, "node-path")
+				err := m.Error()
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Before 'id: second' put the new entry", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{"id": "first", "release": "v1"},
+					map[interface{}]interface{}{"id": "second", "release": "v1"},
+				}
+
+				array := []interface{}{
+					"(( insert before on id \"second\" ))",
+					map[interface{}]interface{}{"id": "new-kid-on-the-block", "release": "vNext"},
+				}
+
+				expect := []interface{}{
+					map[interface{}]interface{}{"id": "first", "release": "v1"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block", "release": "vNext"},
+					map[interface{}]interface{}{"id": "second", "release": "v1"},
+				}
+
+				m := &Merger{}
+				a := m.mergeArray(orig, array, "node-path")
+				err := m.Error()
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
+			})
+
+			Convey("throw an error when insertion point cannot be found", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{"name": "first", "release": "v1"},
+					map[interface{}]interface{}{"name": "second", "release": "v1"},
+				}
+
+				array := []interface{}{
+					"(( insert after on name \"not-existing\" ))",
+					map[interface{}]interface{}{"name": "new-kid-on-the-block", "release": "vNext"},
+				}
+
+				m := &Merger{}
+				a := m.mergeArray(orig, array, "node-path")
+				err := m.Error()
+				So(a, ShouldBeNil)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "unable to find specified insertion point")
+			})
+
+			Convey("throw an error when key cannot be found in new list", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{"id": "first", "release": "v1"},
+					map[interface{}]interface{}{"id": "second", "release": "v1"},
+				}
+
+				array := []interface{}{
+					"(( insert after on id \"second\" ))",
+					map[interface{}]interface{}{"name": "new-kid-on-the-block", "release": "vNext"},
+				}
+
+				m := &Merger{}
+				a := m.mergeArray(orig, array, "node-path")
+				err := m.Error()
+				So(a, ShouldBeNil)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "new object does not contain the key")
+			})
+
+			Convey("throw an error when key cannot be found in original list", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{"name": "first", "release": "v1"},
+					map[interface{}]interface{}{"name": "second", "release": "v1"},
+				}
+
+				array := []interface{}{
+					"(( insert after on id \"second\" ))",
+					map[interface{}]interface{}{"id": "new-kid-on-the-block", "release": "vNext"},
+				}
+
+				m := &Merger{}
+				a := m.mergeArray(orig, array, "node-path")
+				err := m.Error()
+				So(a, ShouldBeNil)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "original object does not contain the key")
+			})
+
+			Convey("throw an error when entry is already in target list", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{"name": "first", "release": "v1"},
+					map[interface{}]interface{}{"name": "second", "release": "v1"},
+				}
+
+				array := []interface{}{
+					"(( insert after on name \"second\" ))",
+					map[interface{}]interface{}{"name": "new-kid-on-the-block", "release": "vNext"},
+					map[interface{}]interface{}{"name": "second", "release": "vNext"},
+				}
+
+				m := &Merger{}
+				a := m.mergeArray(orig, array, "node-path")
+				err := m.Error()
+				So(a, ShouldBeNil)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "because new list entry 1 is detected in both lists")
+			})
 		})
 	})
 }


### PR DESCRIPTION
Hello, we are using Spruce a lot at the moment and we really really like it. One thing which was a bit tricky for us were lists that are compiled from entries across different YAMLs. Some entries are related to others, because they share a common set of configuration, which we solve by using `inject`. However, the order of the list is important to us. So we have to arrange it properly.

To reduce the number of YAMLs, we came up with the idea of having an `(( insert ... ))` operator, which adds array entries at a position of our choice. Pretty much a brother of `(( append ))` and `(( prepend ))`. The syntax is borrowed from `merge`. The actual final syntax is up to debate of course.

This first version will allow you to insert a list at a defined position in the target list. We already have started to think about a version, which allows multiple insert positions if you specify them. But we would like to hear your feedback regarding `(( insert ...)) ` first.

#### Example
Imagine you have a list (jobs, job-templates, releases, resource_pools, ...):
```yml
---
meta:
  list:
  - name: first
    release: v1
  - name: second
    release: v1
  - name: third
    release: v1
  - name: fourth
    release: v1
  - name: fifth
    release: v1
  - name: sixth
    release: v1
```
Now, you want to add a new entry (or more) into that list at a specific position. For the `jobs` list this can become quite handy.
```yml
---
meta:
  list:
  - (( insert after "fifth" ))
  - name: new-kid-on-the-block
    release: vNext
```
This will generate a result list like this:
```yml
---
meta:
  list:
  - name: first
    release: v1
  - name: second
    release: v1
  - name: third
    release: v1
  - name: fourth
    release: v1
  - name: fifth
    release: v1
  - name: new-kid-on-the-block
    release: vNext
  - name: sixth
    release: v1
```
The operator understands so far:
- either `after` or `before` (based on the target position you specify)
- like `merge`, an `on <key>` option to tell which is the entry identifier (default is `name`)
- the name in quotes of the reference entry (insertion point)
- alternatively, you can specify the index number if you have a list without an entry identifier such as `name` (we did not put that into the README, that would be better placed in an extended README on array operations)

What do you think? Especially, I would like to have the possibility to define `(( insert ... ))` a couple of times to be able to have one list while having the flexibility to specify where the entry will end up. This would help us really a lot! As said before, we thought through a couple of use cases already and would be happy to implement that if you think this is useful. Thanks in advance.