### PR TITLE
Add support for multiple array operations (append, prepend, insert) into Spruce

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ the new keys in the file merged on top of the original.
 
 ### What about arrays?
 
-Arrays can be merged in three ways - prepending data, appending data, and completely replacing data.
+Arrays can be modified in multiple ways: prepending data, appending data, inserting data, merging data onto the existing data, or completely replacing data.
 
 - To append data to an existing array, ensure that the first element in the new array is <br>
 
@@ -59,37 +59,6 @@ Arrays can be merged in three ways - prepending data, appending data, and comple
   ```yml
   - (( prepend ))
   ```
-
-- To replace the first array with the second,
-  ensure that the first element in the new array is <br>
-
-  ```yml
-  - (( replace ))
-  ```
-
-- To merge two arrays by way of their index, just make the first
-  element <br>
-
-  ```yml
-  - (( inline ))
-  ```
-
-- To merge two arrays of maps together (using a specific key for identifying like objects), ensure that the first element
-  in the new array is either <br>
-
-  ```yml
-  - (( merge ))
-  ```
-
-  <br> or <br>
-
-  ```yml
-  - (( merge on <key> ))
-  ```
-
-  <br> The first merges using `name` as the key to determine
-  like objects in the array elements. The second is used to customize which key to use. See [Merging Arrays of Maps](#mapmerge)
-  for an example.
 
 - To insert new elements either after or before a specific position of an existing array, you can use `insert` with
   a hint to the respective insertion point in the target list <br>
@@ -123,9 +92,44 @@ Arrays can be merged in three ways - prepending data, appending data, and comple
   - (( insert after <key> "<name>" ))
   - <key>: new-kid-on-the-block
   ```
-  <br> Just like `merge`, the first `insert` is using `name` as the key to determine the target position in the target array.
+  <br> The first `insert` is using `name` as the default key to determine the target position in the target array.
   The second is used to customize which key to use. In any case, instead of `after`, you can also use `before`. This will
   prepend the entries (relative to the specified insertion point).
+
+  <br> The array insertion opertions `(( append ))`, `(( prepend ))`, and `(( insert ... ))` can be used multiple times in
+  one list. They will be processed sequentially and the respective operation applies as long no other insertion operation
+  resets the designated insertion point.
+
+- To replace the first array with the second,
+  ensure that the first element in the new array is <br>
+
+  ```yml
+  - (( replace ))
+  ```
+
+- To merge two arrays by way of their index, just make the first
+  element <br>
+
+  ```yml
+  - (( inline ))
+  ```
+
+- To merge two arrays of maps together (using a specific key for identifying like objects), ensure that the first element
+  in the new array is either <br>
+
+  ```yml
+  - (( merge ))
+  ```
+
+  <br> or <br>
+
+  ```yml
+  - (( merge on <key> ))
+  ```
+
+  <br> The first merges using `name` as the key to determine
+  like objects in the array elements. The second is used to customize which key to use. See [Merging Arrays of Maps](#mapmerge)
+  for an example.
 
 - If you don't specify a specific merge strategy, the array will
   be merged automatically; using keys if they exist (i.e. `((

--- a/merge_test.go
+++ b/merge_test.go
@@ -39,66 +39,7 @@ func TestShouldReplaceArray(t *testing.T) {
 		})
 	})
 }
-func TestShouldAppendToArray(t *testing.T) {
-	Convey("We should append to arrays", t, func() {
-		Convey("If the element is a string with the right append token", func() {
-			So(shouldAppendToArray([]interface{}{"(( append ))", "stuff"}), ShouldBeTrue)
-		})
-		Convey("But not if the element is a string with the wrong token", func() {
-			So(shouldAppendToArray([]interface{}{"not a magic token"}), ShouldBeFalse)
-		})
-		Convey("But not if the element is not a string", func() {
-			So(shouldAppendToArray([]interface{}{42}), ShouldBeFalse)
-		})
-		Convey("But not if the slice has no elements", func() {
-			So(shouldAppendToArray([]interface{}{}), ShouldBeFalse)
-		})
-		Convey("Is whitespace agnostic", func() {
-			Convey("No surrounding whitespace", func() {
-				yes := shouldAppendToArray([]interface{}{"((append))"})
-				So(yes, ShouldBeTrue)
-			})
-			Convey("Surrounding tabs", func() {
-				yes := shouldAppendToArray([]interface{}{"((	append	))"})
-				So(yes, ShouldBeTrue)
-			})
-			Convey("Multiple surrounding whitespaces", func() {
-				yes := shouldAppendToArray([]interface{}{"((  append  ))"})
-				So(yes, ShouldBeTrue)
-			})
-		})
-	})
-}
-func TestShouldPrependToArray(t *testing.T) {
-	Convey("We should prepend to arrays", t, func() {
-		Convey("If the element is a string with the right prepend token", func() {
-			So(shouldPrependToArray([]interface{}{"(( prepend ))", "stuff"}), ShouldBeTrue)
-		})
-		Convey("But not if the element is a string with the wrong token", func() {
-			So(shouldPrependToArray([]interface{}{"not a magic token"}), ShouldBeFalse)
-		})
-		Convey("But not if the element is not a string", func() {
-			So(shouldPrependToArray([]interface{}{42}), ShouldBeFalse)
-		})
-		Convey("But not if the slice has no elements", func() {
-			So(shouldInlineMergeArray([]interface{}{}), ShouldBeFalse)
-		})
-		Convey("Is whitespace agnostic", func() {
-			Convey("No surrounding whitespace", func() {
-				yes := shouldPrependToArray([]interface{}{"((prepend))"})
-				So(yes, ShouldBeTrue)
-			})
-			Convey("Surrounding tabs", func() {
-				yes := shouldPrependToArray([]interface{}{"((	prepend	))"})
-				So(yes, ShouldBeTrue)
-			})
-			Convey("Multiple surrounding whitespaces", func() {
-				yes := shouldPrependToArray([]interface{}{"((  prepend  ))"})
-				So(yes, ShouldBeTrue)
-			})
-		})
-	})
-}
+
 func TestShouldInlineMergeArray(t *testing.T) {
 	Convey("We should inline merge arrays", t, func() {
 		Convey("If the element is a string with the right inline-merge token", func() {
@@ -129,6 +70,7 @@ func TestShouldInlineMergeArray(t *testing.T) {
 		})
 	})
 }
+
 func TestShouldKeyMergeArrayOfHashes(t *testing.T) {
 	Convey("We should key-based merge arrays of hashes", t, func() {
 		Convey("If the element is a string with the right key-merge token", func() {
@@ -201,106 +143,196 @@ func TestShouldKeyMergeArrayOfHashes(t *testing.T) {
 	})
 }
 
-func TestShouldInsertIntoArrayBasedOnIndex(t *testing.T) {
-	Convey("We should insert into arrays based on index", t, func() {
-		Convey("If insert token with after and index is found", func() {
-			result, idx := shouldInsertIntoArrayBasedOnIndex([]interface{}{"(( insert after 0 ))", "stuff"})
-			So(result, ShouldBeTrue)
-			So(idx, ShouldEqual, 1)
+func TestShouldInsertIntoArray(t *testing.T) {
+	Convey("We should insert into arrays based on append/prepend, index, and key/name", t, func() {
+		Convey("Append related test cases", func() {
+			Convey("If the element is a string with the right append token", func() {
+				result, _ := shouldInsertIntoArray([]interface{}{"(( append ))", "stuff"})
+				So(result, ShouldBeTrue)
+			})
+			Convey("But not if the element is not a string", func() {
+				result, _ := shouldInsertIntoArray([]interface{}{42})
+				So(result, ShouldBeFalse)
+			})
+			Convey("But not if the slice has no elements", func() {
+				result, _ := shouldInsertIntoArray([]interface{}{})
+				So(result, ShouldBeFalse)
+			})
+			Convey("Is whitespace agnostic", func() {
+				Convey("No surrounding whitespace", func() {
+					yes, _ := shouldInsertIntoArray([]interface{}{"((append))"})
+					So(yes, ShouldBeTrue)
+				})
+				Convey("Surrounding tabs", func() {
+					yes, _ := shouldInsertIntoArray([]interface{}{"((	append	))"})
+					So(yes, ShouldBeTrue)
+				})
+				Convey("Multiple surrounding whitespaces", func() {
+					yes, _ := shouldInsertIntoArray([]interface{}{"((  append  ))"})
+					So(yes, ShouldBeTrue)
+				})
+			})
 		})
 
-		Convey("If insert token with before and index is found", func() {
-			result, idx := shouldInsertIntoArrayBasedOnIndex([]interface{}{"(( insert before 0 ))", "stuff"})
-			So(result, ShouldBeTrue)
-			So(idx, ShouldEqual, 0)
+		Convey("Prepend related test cases", func() {
+			Convey("If the element is a string with the right prepend token", func() {
+				result, _ := shouldInsertIntoArray([]interface{}{"(( prepend ))", "stuff"})
+				So(result, ShouldBeTrue)
+			})
+			Convey("But not if the element is not a string", func() {
+				result, _ := shouldInsertIntoArray([]interface{}{42})
+				So(result, ShouldBeFalse)
+			})
+			Convey("But not if the slice has no elements", func() {
+				result, _ := shouldInsertIntoArray([]interface{}{})
+				So(result, ShouldBeFalse)
+			})
+			Convey("Is whitespace agnostic", func() {
+				Convey("No surrounding whitespace", func() {
+					yes, _ := shouldInsertIntoArray([]interface{}{"((prepend))"})
+					So(yes, ShouldBeTrue)
+				})
+				Convey("Surrounding tabs", func() {
+					yes, _ := shouldInsertIntoArray([]interface{}{"((	prepend	))"})
+					So(yes, ShouldBeTrue)
+				})
+				Convey("Multiple surrounding whitespaces", func() {
+					yes, _ := shouldInsertIntoArray([]interface{}{"((  prepend  ))"})
+					So(yes, ShouldBeTrue)
+				})
+			})
 		})
 
-		Convey("If insert token with after and index is found independent of missing whitespaces", func() {
-			result, idx := shouldInsertIntoArrayBasedOnIndex([]interface{}{"((insert after 0))", "stuff"})
-			So(result, ShouldBeTrue)
-			So(idx, ShouldEqual, 1)
+		Convey("Insert with index related test cases", func() {
+			Convey("If insert token with after and index is found", func() {
+				result, insertDefinitions := shouldInsertIntoArray([]interface{}{"(( insert after 0 ))", "stuff"})
+				So(result, ShouldBeTrue)
+				So(len(insertDefinitions), ShouldEqual, 1)
+				So(insertDefinitions[0].relative, ShouldEqual, "after")
+				So(insertDefinitions[0].index, ShouldEqual, 0)
+			})
+
+			Convey("If insert token with before and index is found", func() {
+				result, insertDefinitions := shouldInsertIntoArray([]interface{}{"(( insert before 0 ))", "stuff"})
+				So(result, ShouldBeTrue)
+				So(len(insertDefinitions), ShouldEqual, 1)
+				So(insertDefinitions[0].relative, ShouldEqual, "before")
+				So(insertDefinitions[0].index, ShouldEqual, 0)
+			})
+
+			Convey("If insert token with after and index is found independent of missing whitespaces", func() {
+				result, insertDefinitions := shouldInsertIntoArray([]interface{}{"((insert after 0))", "stuff"})
+				So(result, ShouldBeTrue)
+				So(len(insertDefinitions), ShouldEqual, 1)
+				So(insertDefinitions[0].relative, ShouldEqual, "after")
+				So(insertDefinitions[0].index, ShouldEqual, 0)
+			})
+
+			Convey("If insert token with after and index is found with a lot of additional whitespaces", func() {
+				result, insertDefinitions := shouldInsertIntoArray([]interface{}{"((  insert   after   0  ))", "stuff"})
+				So(result, ShouldBeTrue)
+				So(len(insertDefinitions), ShouldEqual, 1)
+				So(insertDefinitions[0].relative, ShouldEqual, "after")
+				So(insertDefinitions[0].index, ShouldEqual, 0)
+			})
+
+			Convey("But not if index is obviously out of bounds", func() {
+				result, insertDefinitions := shouldInsertIntoArray([]interface{}{"(( insert before -1 ))", "stuff"})
+				So(result, ShouldBeFalse)
+				So(insertDefinitions, ShouldBeNil)
+			})
 		})
 
-		Convey("If insert token with after and index is found with a lot of additional whitespaces", func() {
-			result, idx := shouldInsertIntoArrayBasedOnIndex([]interface{}{"((  insert   after   0  ))", "stuff"})
-			So(result, ShouldBeTrue)
-			So(idx, ShouldEqual, 1)
-		})
+		Convey("Insert with key/name related test cases", func() {
+			Convey("If insert token with after, and insertion-name was found", func() {
+				result, insertDefinitions := shouldInsertIntoArray([]interface{}{"(( insert after \"nats\" ))", "stuff"})
+				So(result, ShouldBeTrue)
+				So(insertDefinitions, ShouldNotBeNil)
+				So(len(insertDefinitions), ShouldEqual, 1)
+				So(insertDefinitions[0].relative, ShouldEqual, "after")
+				So(insertDefinitions[0].key, ShouldEqual, "name")
+				So(insertDefinitions[0].name, ShouldEqual, "nats")
+			})
 
-		Convey("But not if index is obviously out of bounds", func() {
-			result, idx := shouldInsertIntoArrayBasedOnIndex([]interface{}{"(( insert before -1 ))", "stuff"})
-			So(result, ShouldBeFalse)
-			So(idx, ShouldEqual, -1)
-		})
+			Convey("If insert token with after, key-name and insertion-name was found", func() {
+				result, insertDefinitions := shouldInsertIntoArray([]interface{}{"(( insert after name \"nats\" ))", "stuff"})
+				So(result, ShouldBeTrue)
+				So(insertDefinitions, ShouldNotBeNil)
+				So(len(insertDefinitions), ShouldEqual, 1)
+				So(insertDefinitions[0].relative, ShouldEqual, "after")
+				So(insertDefinitions[0].key, ShouldEqual, "name")
+				So(insertDefinitions[0].name, ShouldEqual, "nats")
+			})
 
-		Convey("But not if the magic token is not specified", func() {
-			result, idx := shouldInsertIntoArrayBasedOnIndex([]interface{}{"not a magic token", "stuff"})
-			So(result, ShouldBeFalse)
-			So(idx, ShouldEqual, -1)
-		})
+			Convey("If insert token with before, another custom key-name and insertion-name was found", func() {
+				result, insertDefinitions := shouldInsertIntoArray([]interface{}{"(( insert before id \"ccdb\" ))", "stuff"})
+				So(result, ShouldBeTrue)
+				So(insertDefinitions, ShouldNotBeNil)
+				So(len(insertDefinitions), ShouldEqual, 1)
+				So(insertDefinitions[0].relative, ShouldEqual, "before")
+				So(insertDefinitions[0].key, ShouldEqual, "id")
+				So(insertDefinitions[0].name, ShouldEqual, "ccdb")
+			})
 
-		Convey("But not if the index is somehow quoted (and therefore not integer)", func() {
-			result, idx := shouldInsertIntoArrayBasedOnIndex([]interface{}{"(( insert after \"0\" ))", "stuff"})
-			So(result, ShouldBeFalse)
-			So(idx, ShouldEqual, -1)
-		})
+			Convey("If insert token with after, key-name and insertion-name was found without additional whitespaces", func() {
+				result, insertDefinitions := shouldInsertIntoArray([]interface{}{"((insert after name \"nats\"))", "stuff"})
+				So(result, ShouldBeTrue)
+				So(insertDefinitions, ShouldNotBeNil)
+				So(len(insertDefinitions), ShouldEqual, 1)
+				So(insertDefinitions[0].relative, ShouldEqual, "after")
+				So(insertDefinitions[0].key, ShouldEqual, "name")
+				So(insertDefinitions[0].name, ShouldEqual, "nats")
+			})
 
-		Convey("But not if there is actually a different type of position style is wanted", func() {
-			result, idx := shouldInsertIntoArrayBasedOnIndex([]interface{}{"(( insert after \"foobar\" ))", "stuff"})
-			So(result, ShouldBeFalse)
-			So(idx, ShouldEqual, -1)
-		})
-	})
-}
+			Convey("If insert token with after, key-name and insertion-name was found with additional whitespaces", func() {
+				result, insertDefinitions := shouldInsertIntoArray([]interface{}{"((   insert   after     name   \"nats\"   ))", "stuff"})
+				So(result, ShouldBeTrue)
+				So(insertDefinitions, ShouldNotBeNil)
+				So(len(insertDefinitions), ShouldEqual, 1)
+				So(insertDefinitions[0].relative, ShouldEqual, "after")
+				So(insertDefinitions[0].key, ShouldEqual, "name")
+				So(insertDefinitions[0].name, ShouldEqual, "nats")
+			})
 
-func TestShouldInsertIntoArrayBasedOnName(t *testing.T) {
-	Convey("We should insert into arrays based on key and name", t, func() {
-		Convey("If insert token with after, and insertion-name was found", func() {
-			result, relative, key, name := shouldInsertIntoArrayBasedOnName([]interface{}{"(( insert after \"nats\" ))", "stuff"})
-			So(result, ShouldBeTrue)
-			So(relative, ShouldEqual, "after")
-			So(key, ShouldEqual, "name")
-			So(name, ShouldEqual, "nats")
-		})
+			Convey("If insert token with after, key-name and insertion-name was found, but the list is empty", func() {
+				result, insertDefinitions := shouldInsertIntoArray([]interface{}{"(( insert after name \"nats\" ))"})
+				So(result, ShouldBeTrue)
+				So(insertDefinitions, ShouldNotBeNil)
+				So(len(insertDefinitions), ShouldEqual, 1)
+				So(insertDefinitions[0].relative, ShouldEqual, "after")
+				So(insertDefinitions[0].key, ShouldEqual, "name")
+				So(insertDefinitions[0].name, ShouldEqual, "nats")
+				So(insertDefinitions[0].list, ShouldBeNil)
+			})
 
-		Convey("If insert token with after, key-name and insertion-name was found", func() {
-			result, relative, key, name := shouldInsertIntoArrayBasedOnName([]interface{}{"(( insert after name \"nats\" ))", "stuff"})
-			So(result, ShouldBeTrue)
-			So(relative, ShouldEqual, "after")
-			So(key, ShouldEqual, "name")
-			So(name, ShouldEqual, "nats")
-		})
+			Convey("If there are multiple insert token with after/before, different key names, and names (only technical usecase)", func() {
+				result, insertDefinitions := shouldInsertIntoArray([]interface{}{
+					"(( insert after name \"nats\" ))",
+					"stuff1",
+					"stuff2",
+					"stuff3",
+					"(( insert before id \"consul\" ))",
+					"stuffX1",
+					"stuffX2",
+				})
+				So(result, ShouldBeTrue)
+				So(insertDefinitions, ShouldNotBeNil)
+				So(len(insertDefinitions), ShouldEqual, 2)
+				So(insertDefinitions[0].relative, ShouldEqual, "after")
+				So(insertDefinitions[0].key, ShouldEqual, "name")
+				So(insertDefinitions[0].name, ShouldEqual, "nats")
+				So(insertDefinitions[0].list, ShouldResemble, []interface{}{"stuff1", "stuff2", "stuff3"})
+				So(insertDefinitions[1].relative, ShouldEqual, "before")
+				So(insertDefinitions[1].key, ShouldEqual, "id")
+				So(insertDefinitions[1].name, ShouldEqual, "consul")
+				So(insertDefinitions[1].list, ShouldResemble, []interface{}{"stuffX1", "stuffX2"})
+			})
 
-		Convey("If insert token with before, another custom key-name and insertion-name was found", func() {
-			result, relative, key, name := shouldInsertIntoArrayBasedOnName([]interface{}{"(( insert before id \"ccdb\" ))", "stuff"})
-			So(result, ShouldBeTrue)
-			So(relative, ShouldEqual, "before")
-			So(key, ShouldEqual, "id")
-			So(name, ShouldEqual, "ccdb")
-		})
-
-		Convey("If insert token with after, key-name and insertion-name was found without additional whitespaces", func() {
-			result, relative, key, name := shouldInsertIntoArrayBasedOnName([]interface{}{"((insert after name \"nats\"))", "stuff"})
-			So(result, ShouldBeTrue)
-			So(relative, ShouldEqual, "after")
-			So(key, ShouldEqual, "name")
-			So(name, ShouldEqual, "nats")
-		})
-
-		Convey("If insert token with after, key-name and insertion-name was found with additional whitespaces", func() {
-			result, relative, key, name := shouldInsertIntoArrayBasedOnName([]interface{}{"((   insert   after   name   \"nats\"   ))", "stuff"})
-			So(result, ShouldBeTrue)
-			So(relative, ShouldEqual, "after")
-			So(key, ShouldEqual, "name")
-			So(name, ShouldEqual, "nats")
-		})
-
-		Convey("But not if the magic token is not specified", func() {
-			result, relative, key, name := shouldInsertIntoArrayBasedOnName([]interface{}{"not a magic token", "stuff"})
-			So(result, ShouldBeFalse)
-			So(relative, ShouldEqual, "")
-			So(key, ShouldEqual, "")
-			So(name, ShouldEqual, "")
+			Convey("But not if the magic token is not specified", func() {
+				result, insertDefinitions := shouldInsertIntoArray([]interface{}{"not a magic token", "stuff"})
+				So(result, ShouldBeFalse)
+				So(insertDefinitions, ShouldBeNil)
+			})
 		})
 	})
 }
@@ -1085,6 +1117,240 @@ func TestMergeArray(t *testing.T) {
 				So(err, ShouldBeNil)
 			})
 
+			Convey("Insert multiple new entries before second and after first", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{"id": "first", "release": "v1"},
+					map[interface{}]interface{}{"id": "second", "release": "v1"},
+				}
+
+				array := []interface{}{
+					"(( insert before id \"second\" ))",
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-1", "release": "vNext"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-2", "release": "vNext"},
+					"(( insert after id \"first\" ))",
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-3", "release": "vNext"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-4", "release": "vNext"},
+				}
+
+				expect := []interface{}{
+					map[interface{}]interface{}{"id": "first", "release": "v1"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-3", "release": "vNext"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-4", "release": "vNext"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-1", "release": "vNext"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-2", "release": "vNext"},
+					map[interface{}]interface{}{"id": "second", "release": "v1"},
+				}
+
+				m := &Merger{}
+				a := m.mergeArray(orig, array, "node-path")
+				err := m.Error()
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Insert multiple new entries in two batches after first", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{"id": "first", "release": "v1"},
+					map[interface{}]interface{}{"id": "second", "release": "v1"},
+				}
+
+				array := []interface{}{
+					"(( insert after id \"first\" ))",
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-1", "release": "vNext"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-2", "release": "vNext"},
+					"(( insert after id \"first\" ))",
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-3", "release": "vNext"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-4", "release": "vNext"},
+				}
+
+				expect := []interface{}{
+					map[interface{}]interface{}{"id": "first", "release": "v1"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-3", "release": "vNext"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-4", "release": "vNext"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-1", "release": "vNext"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-2", "release": "vNext"},
+					map[interface{}]interface{}{"id": "second", "release": "v1"},
+				}
+
+				m := &Merger{}
+				a := m.mergeArray(orig, array, "node-path")
+				err := m.Error()
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Insert multiple new entries in three batches after first", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{"id": "first", "release": "v1"},
+					map[interface{}]interface{}{"id": "second", "release": "v1"},
+				}
+
+				array := []interface{}{
+					"(( insert after id \"first\" ))",
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-1", "release": "vNext"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-2", "release": "vNext"},
+					"(( insert after id \"first\" ))",
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-3", "release": "vNext"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-4", "release": "vNext"},
+					"(( insert after id \"first\" ))",
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-5", "release": "vNext"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-6", "release": "vNext"},
+				}
+
+				expect := []interface{}{
+					map[interface{}]interface{}{"id": "first", "release": "v1"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-5", "release": "vNext"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-6", "release": "vNext"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-3", "release": "vNext"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-4", "release": "vNext"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-1", "release": "vNext"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-2", "release": "vNext"},
+					map[interface{}]interface{}{"id": "second", "release": "v1"},
+				}
+
+				m := &Merger{}
+				a := m.mergeArray(orig, array, "node-path")
+				err := m.Error()
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Insert multiple new entries in different batches", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{"id": "first", "release": "v1"},
+					map[interface{}]interface{}{"id": "second", "release": "v1"},
+					map[interface{}]interface{}{"id": "third", "release": "v1"},
+					map[interface{}]interface{}{"id": "fourth", "release": "v1"},
+					map[interface{}]interface{}{"id": "fifth", "release": "v1"},
+					map[interface{}]interface{}{"id": "sixth", "release": "v1"},
+					map[interface{}]interface{}{"id": "seventh", "release": "v1"},
+					map[interface{}]interface{}{"id": "eighth", "release": "v1"},
+				}
+
+				array := []interface{}{
+					"(( insert after id \"second\" ))",
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-1", "release": "vNext"},
+					"(( insert after id \"fourth\" ))",
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-2", "release": "vNext"},
+					"(( insert after id \"sixth\" ))",
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-3", "release": "vNext"},
+				}
+
+				expect := []interface{}{
+					map[interface{}]interface{}{"id": "first", "release": "v1"},
+					map[interface{}]interface{}{"id": "second", "release": "v1"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-1", "release": "vNext"},
+					map[interface{}]interface{}{"id": "third", "release": "v1"},
+					map[interface{}]interface{}{"id": "fourth", "release": "v1"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-2", "release": "vNext"},
+					map[interface{}]interface{}{"id": "fifth", "release": "v1"},
+					map[interface{}]interface{}{"id": "sixth", "release": "v1"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-3", "release": "vNext"},
+					map[interface{}]interface{}{"id": "seventh", "release": "v1"},
+					map[interface{}]interface{}{"id": "eighth", "release": "v1"},
+				}
+
+				m := &Merger{}
+				a := m.mergeArray(orig, array, "node-path")
+				err := m.Error()
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Insert multiple new entries in different batches with empty lists", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{"id": "first", "release": "v1"},
+					map[interface{}]interface{}{"id": "second", "release": "v1"},
+					map[interface{}]interface{}{"id": "third", "release": "v1"},
+					map[interface{}]interface{}{"id": "fourth", "release": "v1"},
+					map[interface{}]interface{}{"id": "fifth", "release": "v1"},
+					map[interface{}]interface{}{"id": "sixth", "release": "v1"},
+					map[interface{}]interface{}{"id": "seventh", "release": "v1"},
+					map[interface{}]interface{}{"id": "eighth", "release": "v1"},
+				}
+
+				array := []interface{}{
+					"(( insert after id \"second\" ))",
+					"(( insert after id \"fourth\" ))",
+					"(( insert after id \"sixth\" ))",
+					map[interface{}]interface{}{"id": "new-kid-on-the-block", "release": "vNext"},
+				}
+
+				expect := []interface{}{
+					map[interface{}]interface{}{"id": "first", "release": "v1"},
+					map[interface{}]interface{}{"id": "second", "release": "v1"},
+					map[interface{}]interface{}{"id": "third", "release": "v1"},
+					map[interface{}]interface{}{"id": "fourth", "release": "v1"},
+					map[interface{}]interface{}{"id": "fifth", "release": "v1"},
+					map[interface{}]interface{}{"id": "sixth", "release": "v1"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block", "release": "vNext"},
+					map[interface{}]interface{}{"id": "seventh", "release": "v1"},
+					map[interface{}]interface{}{"id": "eighth", "release": "v1"},
+				}
+
+				m := &Merger{}
+				a := m.mergeArray(orig, array, "node-path")
+				err := m.Error()
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Insert multiple new entries in with different insertion styles", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{"id": "first", "release": "v1"},
+					map[interface{}]interface{}{"id": "second", "release": "v1"},
+					map[interface{}]interface{}{"id": "third", "release": "v1"},
+					map[interface{}]interface{}{"id": "fourth", "release": "v1"},
+					map[interface{}]interface{}{"id": "fifth", "release": "v1"},
+					map[interface{}]interface{}{"id": "sixth", "release": "v1"},
+					map[interface{}]interface{}{"id": "seventh", "release": "v1"},
+					map[interface{}]interface{}{"id": "eighth", "release": "v1"},
+				}
+
+				array := []interface{}{
+					"(( insert after id \"second\" ))",
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-1", "release": "vNext"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-2", "release": "vNext"},
+					"(( prepend ))",
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-3", "release": "vNext"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-4", "release": "vNext"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-5", "release": "vNext"},
+					"(( append ))",
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-6", "release": "vNext"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-7", "release": "vNext"},
+					"(( insert before id \"fourth\" ))",
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-8", "release": "vNext"},
+					"(( insert after 0 ))",
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-9", "release": "vNext"},
+				}
+
+				expect := []interface{}{
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-3", "release": "vNext"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-9", "release": "vNext"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-4", "release": "vNext"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-5", "release": "vNext"},
+					map[interface{}]interface{}{"id": "first", "release": "v1"},
+					map[interface{}]interface{}{"id": "second", "release": "v1"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-1", "release": "vNext"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-2", "release": "vNext"},
+					map[interface{}]interface{}{"id": "third", "release": "v1"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-8", "release": "vNext"},
+					map[interface{}]interface{}{"id": "fourth", "release": "v1"},
+					map[interface{}]interface{}{"id": "fifth", "release": "v1"},
+					map[interface{}]interface{}{"id": "sixth", "release": "v1"},
+					map[interface{}]interface{}{"id": "seventh", "release": "v1"},
+					map[interface{}]interface{}{"id": "eighth", "release": "v1"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-6", "release": "vNext"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block-7", "release": "vNext"},
+				}
+
+				m := &Merger{}
+				a := m.mergeArray(orig, array, "node-path")
+				err := m.Error()
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
+			})
+
 			Convey("throw an error when insertion point cannot be found", func() {
 				orig := []interface{}{
 					map[interface{}]interface{}{"name": "first", "release": "v1"},
@@ -1159,7 +1425,7 @@ func TestMergeArray(t *testing.T) {
 				err := m.Error()
 				So(a, ShouldBeNil)
 				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldContainSubstring, "because new list entry 1 is detected in both lists")
+				So(err.Error(), ShouldContainSubstring, "because new list entry 'name: second' is detected multiple times")
 			})
 		})
 	})

--- a/merge_test.go
+++ b/merge_test.go
@@ -1351,6 +1351,80 @@ func TestMergeArray(t *testing.T) {
 				So(err, ShouldBeNil)
 			})
 
+			Convey("Insert multiple new entries in with different insertion styles which depend on each other (without name keys)", func() {
+				orig := []interface{}{
+					"1",
+					"2",
+					"3",
+				}
+
+				array := []interface{}{
+					"(( prepend ))",
+					"this thing",
+					"that thing",
+					"(( insert before 1 ))",
+					"first insert",
+					"(( insert before 2 ))",
+					"second insert",
+					"(( insert before 6 ))",
+					"stuff",
+				}
+
+				expect := []interface{}{
+					"this thing",
+					"first insert",
+					"second insert",
+					"that thing",
+					"1",
+					"2",
+					"stuff",
+					"3",
+				}
+
+				m := &Merger{}
+				a := m.mergeArray(orig, array, "node-path")
+				err := m.Error()
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Insert multiple new entries in with different insertion styles which depend on each other (with id keys)", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{"id": "1"},
+					map[interface{}]interface{}{"id": "2"},
+					map[interface{}]interface{}{"id": "3"},
+				}
+
+				array := []interface{}{
+					"(( prepend ))",
+					map[interface{}]interface{}{"id": "this thing"},
+					map[interface{}]interface{}{"id": "that thing"},
+					"(( insert after id \"this thing\" ))",
+					map[interface{}]interface{}{"id": "first insert"},
+					"(( insert after id \"first insert\" ))",
+					map[interface{}]interface{}{"id": "second insert"},
+					"(( insert after id \"2\" ))",
+					map[interface{}]interface{}{"id": "stuff"},
+				}
+
+				expect := []interface{}{
+					map[interface{}]interface{}{"id": "this thing"},
+					map[interface{}]interface{}{"id": "first insert"},
+					map[interface{}]interface{}{"id": "second insert"},
+					map[interface{}]interface{}{"id": "that thing"},
+					map[interface{}]interface{}{"id": "1"},
+					map[interface{}]interface{}{"id": "2"},
+					map[interface{}]interface{}{"id": "stuff"},
+					map[interface{}]interface{}{"id": "3"},
+				}
+
+				m := &Merger{}
+				a := m.mergeArray(orig, array, "node-path")
+				err := m.Error()
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
+			})
+
 			Convey("throw an error when insertion point cannot be found", func() {
 				orig := []interface{}{
 					map[interface{}]interface{}{"name": "first", "release": "v1"},


### PR DESCRIPTION
Hey, as discussed in [in the other pull request](https://github.com/geofffranks/spruce/pull/135), it would be cool to be able to specify multiple `append`, `prepend`, and `insert` statements in one list to allow something like:
```yml
---
list:
  - (( append ))
  - tail
  - part
  - (( prepend ))
  - head
  - list
```
To do that, I thought it would be best to consolidate the insertion operations into one check, which creates a list of TODOs (append this list, insert this list, append this list, ...) for the `mergeArray` function.

This also meant to modify the `append` and `prepend` test cases to match the new name of the internal function. Some new test cases were added to check that a combination of `append`, `prepend`, and `insert` will work in one list.

The rule that such a list must start with `append`, `prepend`, or `insert` still applies.

I think it would be good to write a `README` for this in the examples section to show more complex scenarios.

What do you think of the suggestion? 
