### PR TITLE
Switch Eval / Param phases

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,6 @@
+# Improvements
+
+- Error messages from `(( param ... ))` oeprators are now
+  de-duplicated from `(( grab ... ))` propagation, leading to more
+  clear direction with heavily parameterized BOSH manifests.
+  Fixes #129

--- a/evaluator.go
+++ b/evaluator.go
@@ -372,6 +372,11 @@ func (ev *Evaluator) Run(prune []string) error {
 	paramErrs := MultiError{Errors: []error{}}
 
 	errors.Append(ev.RunPhase(MergePhase))
+	paramErrs.Append(ev.RunPhase(ParamPhase))
+	if len(paramErrs.Errors) > 0 {
+		return paramErrs
+	}
+
 	errors.Append(ev.RunPhase(EvalPhase))
 
 	// this is a big failure...
@@ -379,13 +384,8 @@ func (ev *Evaluator) Run(prune []string) error {
 		return err
 	}
 
-	paramErrs.Append(ev.RunPhase(ParamPhase))
 	errors.Append(ev.Prune(append(keysToPrune, prune...)))
 	keysToPrune = nil
-
-	if len(paramErrs.Errors) > 0 {
-		return paramErrs
-	}
 
 	if len(errors.Errors) > 0 {
 		return errors

--- a/evaluator_test.go
+++ b/evaluator_test.go
@@ -1545,11 +1545,13 @@ value: (( grab meta.key ))
 `),
 			}
 
-			err := ev.RunPhase(EvalPhase)
-			So(err, ShouldBeNil)
-			err = ev.RunPhase(ParamPhase)
+			err := ev.RunPhase(ParamPhase)
 			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldContainSubstring, "1 error(s) detected")
 			So(err.Error(), ShouldContainSubstring, "you must specify this")
+
+			err = ev.RunPhase(EvalPhase)
+			So(err, ShouldBeNil)
 		})
 
 		Convey("detects unsatisfied (( param )) inside of a (( concat ... )) call", func() {
@@ -1562,11 +1564,13 @@ value: (( concat "key=" meta.key ))
 `),
 			}
 
-			err := ev.RunPhase(EvalPhase)
-			So(err, ShouldBeNil)
-			err = ev.RunPhase(ParamPhase)
+			err := ev.RunPhase(ParamPhase)
 			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldContainSubstring, "1 error(s) detected")
 			So(err.Error(), ShouldContainSubstring, "you must specify this")
+
+			err = ev.RunPhase(EvalPhase)
+			So(err, ShouldBeNil)
 		})
 
 		Convey("handles non-list (direct) args to (( cartesian-product ... ))", func() {


### PR DESCRIPTION
Now we check for parameter overrides immediately after the merge phase,
since defering until after eval phase just leads to propagation of
`(( param ...))` calls and more confusion.

Fixes #129