### PR TITLE
Change prune internals to fix prune side-effects with inject

### DIFF
--- a/assets/prune/prune-in-lists/fileA.yml
+++ b/assets/prune/prune-in-lists/fileA.yml
@@ -1,0 +1,6 @@
+---
+meta:
+  list:
+  - one
+  - two
+  - three

--- a/assets/prune/prune-in-lists/fileB.yml
+++ b/assets/prune/prune-in-lists/fileB.yml
@@ -1,0 +1,5 @@
+---
+meta:
+  list:
+  - one
+  - (( prune ))

--- a/assets/prune/prune-issue-in-lists-with-new-entry/fileA.yml
+++ b/assets/prune/prune-issue-in-lists-with-new-entry/fileA.yml
@@ -1,0 +1,13 @@
+---
+list:
+- name: A
+  release: A
+  version: A
+
+- name: B
+  release: B
+  version: B
+
+- name: C
+  release: C
+  version: C

--- a/assets/prune/prune-issue-in-lists-with-new-entry/fileB.yml
+++ b/assets/prune/prune-issue-in-lists-with-new-entry/fileB.yml
@@ -1,0 +1,5 @@
+---
+list:
+- name: D
+  release: D
+  version: (( prune ))

--- a/assets/prune/prune-issue-with-inject/fileA.yml
+++ b/assets/prune/prune-issue-with-inject/fileA.yml
@@ -1,0 +1,14 @@
+---
+meta:
+  default:
+    templates:
+    - name: one
+    - name: two
+    update:
+      canaries: 1
+      max_in_flight: 3
+
+jobs:
+- name: main-job
+  <<<: (( inject meta.default ))
+  instances: 2

--- a/assets/prune/prune-issue-with-inject/fileB.yml
+++ b/assets/prune/prune-issue-with-inject/fileB.yml
@@ -1,0 +1,8 @@
+---
+jobs:
+- name: another-job
+  <<<: (( inject meta.default ))
+  instances: 1
+  update:
+    canaries: 2
+    max_in_flight: (( prune ))

--- a/cmd/spruce/main_test.go
+++ b/cmd/spruce/main_test.go
@@ -545,6 +545,56 @@ quux: quux
 			So(stdout, ShouldEqual, "")
 			So(stderr, ShouldContainSubstring, "Root of YAML document is not a hash/map:")
 		})
+
+		Convey("Issue - prune and inject cause side-effect", func() {
+			os.Args = []string{"spruce", "merge", "--prune", "meta", "../../assets/prune/prune-issue-with-inject/fileA.yml", "../../assets/prune/prune-issue-with-inject/fileB.yml"}
+			stdout = ""
+			stderr = ""
+
+			main()
+			So(stderr, ShouldEqual, "")
+			So(stdout, ShouldEqual, `jobs:
+- instances: 2
+  name: main-job
+  templates:
+  - name: one
+  - name: two
+  update:
+    canaries: 1
+    max_in_flight: 3
+- instances: 1
+  name: another-job
+  templates:
+  - name: one
+  - name: two
+  update:
+    canaries: 2
+
+`)
+		})
+
+		Convey("Issue - prune and new-list-entry cause side-effect", func() {
+			os.Args = []string{"spruce", "merge", "--prune", "meta", "../../assets/prune/prune-issue-in-lists-with-new-entry/fileA.yml", "../../assets/prune/prune-issue-in-lists-with-new-entry/fileB.yml"}
+			stdout = ""
+			stderr = ""
+
+			main()
+			So(stderr, ShouldEqual, "")
+			So(stdout, ShouldEqual, `list:
+  - name: A
+    release: A
+    version: A
+  - name: B
+    release: B
+    version: B
+  - name: C
+    release: C
+    version: C
+  - name: D
+    release: D
+
+`)
+		})
 	})
 }
 

--- a/cmd/spruce/main_test.go
+++ b/cmd/spruce/main_test.go
@@ -546,6 +546,36 @@ quux: quux
 			So(stderr, ShouldContainSubstring, "Root of YAML document is not a hash/map:")
 		})
 
+		Convey("Adding (dynamic) prune support for list entries (edge case scenario)", func() {
+			os.Args = []string{"spruce", "merge", "../../assets/prune/prune-in-lists/fileA.yml", "../../assets/prune/prune-in-lists/fileB.yml"}
+			stdout = ""
+			stderr = ""
+
+			main()
+			So(stderr, ShouldEqual, "")
+			So(stdout, ShouldEqual, `meta:
+  list:
+  - one
+  - three
+
+`)
+		})
+
+		Convey("Adding (static) prune support for list entries (edge case scenario)", func() {
+			os.Args = []string{"spruce", "merge", "--prune", "meta.list.1", "../../assets/prune/prune-in-lists/fileA.yml"}
+			stdout = ""
+			stderr = ""
+
+			main()
+			So(stderr, ShouldEqual, "")
+			So(stdout, ShouldEqual, `meta:
+  list:
+  - one
+  - three
+
+`)
+		})
+
 		Convey("Issue - prune and inject cause side-effect", func() {
 			os.Args = []string{"spruce", "merge", "--prune", "meta", "../../assets/prune/prune-issue-with-inject/fileA.yml", "../../assets/prune/prune-issue-with-inject/fileB.yml"}
 			stdout = ""

--- a/cmd/spruce/main_test.go
+++ b/cmd/spruce/main_test.go
@@ -808,5 +808,15 @@ func TestExamples(t *testing.T) {
 				"../../examples/inject/output.yml",
 			)
 		})
+
+		Convey("Pruning", func() {
+			example(
+				"../../examples/pruning/base.yml",
+				"../../examples/pruning/jobs.yml",
+				"../../examples/pruning/networks.yml",
+
+				"../../examples/pruning/output.yml",
+			)
+		})
 	})
 }

--- a/cmd/spruce/main_test.go
+++ b/cmd/spruce/main_test.go
@@ -581,17 +581,17 @@ quux: quux
 			main()
 			So(stderr, ShouldEqual, "")
 			So(stdout, ShouldEqual, `list:
-  - name: A
-    release: A
-    version: A
-  - name: B
-    release: B
-    version: B
-  - name: C
-    release: C
-    version: C
-  - name: D
-    release: D
+- name: A
+  release: A
+  version: A
+- name: B
+  release: B
+  version: B
+- name: C
+  release: C
+  version: C
+- name: D
+  release: D
 
 `)
 		})

--- a/evaluator.go
+++ b/evaluator.go
@@ -11,8 +11,6 @@ import (
 	"github.com/starkandwayne/goutils/tree"
 )
 
-var keysToPrune []string
-
 // Evaluator ...
 type Evaluator struct {
 	Tree map[interface{}]interface{}
@@ -384,7 +382,8 @@ func (ev *Evaluator) Run(prune []string) error {
 		return err
 	}
 
-	errors.Append(ev.Prune(append(keysToPrune, prune...)))
+	addToPruneListIfNecessary(prune...)
+	errors.Append(ev.Prune(keysToPrune))
 	keysToPrune = nil
 
 	if len(errors.Errors) > 0 {

--- a/evaluator.go
+++ b/evaluator.go
@@ -246,7 +246,7 @@ func (ev *Evaluator) Prune(paths []string) error {
 			}
 
 		default:
-			DEBUG("  I don't know how to prune %s\n    value=%v\n     type=%v\n", path, o, reflect.TypeOf(o))
+			DEBUG("  I don't know how to prune %s\n    value=%v\n", path, o)
 		}
 	}
 	DEBUG("")

--- a/merge.go
+++ b/merge.go
@@ -95,6 +95,7 @@ func (m *Merger) mergeMap(orig map[interface{}]interface{}, n map[interface{}]in
 }
 
 func (m *Merger) mergeObj(orig interface{}, n interface{}, node string) interface{} {
+	// prune has a special behavior: even if the value is replaced during processing, the key will be removed at the end of the processing
 	pruneRx := regexp.MustCompile(`^\s*\Q((\E\s*prune\s*\Q))\E`)
 	if orig != nil && reflect.TypeOf(orig).Kind() == reflect.String && pruneRx.MatchString(orig.(string)) {
 		DEBUG("%s: a (( prune )) operator is about to be replaced, check if its path needs to be saved")

--- a/op_prune.go
+++ b/op_prune.go
@@ -1,0 +1,66 @@
+package spruce
+
+import (
+	"fmt"
+
+	"github.com/starkandwayne/goutils/tree"
+
+	. "github.com/geofffranks/spruce/log"
+)
+
+var keysToPrune []string
+
+func addToPruneListIfNecessary(paths ...string) {
+	for _, path := range paths {
+		if !isIncluded(keysToPrune, path) {
+			DEBUG("adding '%s' to the list of paths to prune", path)
+			keysToPrune = append(keysToPrune, path)
+		}
+	}
+}
+
+func isIncluded(list []string, name string) bool {
+	for _, entry := range list {
+		if entry == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+// PruneOperator ...
+type PruneOperator struct{}
+
+// Setup ...
+func (PruneOperator) Setup() error {
+	return nil
+}
+
+// Phase ...
+func (PruneOperator) Phase() OperatorPhase {
+	return EvalPhase
+}
+
+// Dependencies ...
+func (PruneOperator) Dependencies(_ *Evaluator, _ []*Expr, _ []*tree.Cursor) []*tree.Cursor {
+	return []*tree.Cursor{}
+}
+
+// Run ...
+func (PruneOperator) Run(ev *Evaluator, args []*Expr) (*Response, error) {
+	DEBUG("running (( prune ... )) operation at $.%s", ev.Here)
+	defer DEBUG("done with (( prune ... )) operation at $.%s\n", ev.Here)
+
+	addToPruneListIfNecessary(fmt.Sprintf("%s", ev.Here))
+
+	// simply replace it with an empty string (will be pruned at the end anyway)
+	return &Response{
+		Type:  Replace,
+		Value: "",
+	}, nil
+}
+
+func init() {
+	RegisterOp("prune", PruneOperator{})
+}

--- a/op_prune.go
+++ b/op_prune.go
@@ -54,7 +54,7 @@ func (PruneOperator) Run(ev *Evaluator, args []*Expr) (*Response, error) {
 
 	addToPruneListIfNecessary(fmt.Sprintf("%s", ev.Here))
 
-	// simply replace it with an empty string (will be pruned at the end anyway)
+	// simply replace it with nil (will be pruned at the end anyway)
 	return &Response{
 		Type:  Replace,
 		Value: nil,

--- a/op_prune.go
+++ b/op_prune.go
@@ -57,7 +57,7 @@ func (PruneOperator) Run(ev *Evaluator, args []*Expr) (*Response, error) {
 	// simply replace it with an empty string (will be pruned at the end anyway)
 	return &Response{
 		Type:  Replace,
-		Value: "",
+		Value: nil,
 	}, nil
 }
 


### PR DESCRIPTION
We did a couple of checks and think this change would solve the issue #150 by modifying how and when the prune operator will be evaluated.

Adding a path to the list of paths to prune will be deferred as long as possible in order find out the exact path in a merged result, which will help with prune in lists.

To behave like before, this meant that there is one special check in the merge object routines that save the prune path in case the actual `key: (( prune ))` is about to be overwritten. This, for example, is needed in the `networks` example that came with `(( prune ))`.

In order to work with `(( inject ))` it was necessary that the `key: (( prune ))` is actually part of the structure to let `(( inject ))` decide whether which entry takes precedence in the merge.

@jhunt @geofffranks @JamesClonk  What do you think?