### PR TITLE
Emptyop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ releases
 artifacts
 .svtoken
 *.swp
+.vscode

--- a/assets/empty/base.yml
+++ b/assets/empty/base.yml
@@ -1,0 +1,8 @@
+---
+meta:
+  first:
+    foo: bar
+  second:
+    beep: boop
+  third:
+    wom: bat

--- a/assets/empty/literals.yml
+++ b/assets/empty/literals.yml
@@ -1,0 +1,5 @@
+---
+meta:
+  first: (( empty "hash" ))
+  second: (( empty "array" ))
+  third: (( empty "string" ))

--- a/assets/empty/references.yml
+++ b/assets/empty/references.yml
@@ -1,0 +1,5 @@
+---
+meta: 
+  first: (( empty hash ))
+  second: (( empty array ))
+  third: (( empty string ))

--- a/cmd/spruce/main_test.go
+++ b/cmd/spruce/main_test.go
@@ -649,6 +649,52 @@ quux: quux
 
 `)
 		})
+
+		Convey("Empty operator works", func() {
+
+			var baseFile, mergeFile string
+			baseFile = "../../assets/empty/base.yml"
+
+			testEmpty := func(files ...string) {
+				os.Args = append([]string{"spruce", "merge"}, files...)
+				stdout = ""
+				stderr = ""
+				main()
+				So(stderr, ShouldEqual, "")
+				So(stdout, ShouldEqual, `meta:
+  first: {}
+  second: []
+  third: ""
+
+`)
+			}
+
+			Convey("when merging over maps", func() {
+
+				Convey("with references as the type", func() {
+					mergeFile = "../../assets/empty/references.yml"
+					testEmpty(baseFile, mergeFile)
+				})
+				Convey("with literals as the type", func() {
+					mergeFile = "../../assets/empty/literals.yml"
+					testEmpty(baseFile, mergeFile)
+				})
+			})
+
+			Convey("Merging over nothing", func() {
+
+				Convey("when merging over maps", func() {
+					Convey("with references as the type", func() {
+						mergeFile = "../../assets/empty/references.yml"
+						testEmpty(mergeFile)
+					})
+					Convey("with literals as the type", func() {
+						mergeFile = "../../assets/empty/literals.yml"
+						testEmpty(mergeFile)
+					})
+				})
+			})
+		})
 	})
 }
 

--- a/op_empty.go
+++ b/op_empty.go
@@ -1,0 +1,69 @@
+package spruce
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/starkandwayne/goutils/tree"
+)
+
+// EmptyOperator allows the user to emplace an empty array, hash, or string into
+// the YAML datastructure.
+type EmptyOperator struct{}
+
+// Setup ...
+func (EmptyOperator) Setup() error {
+	return nil
+}
+
+// Phase ...
+func (EmptyOperator) Phase() OperatorPhase {
+	return EvalPhase
+}
+
+// Dependencies ...
+func (EmptyOperator) Dependencies(_ *Evaluator, _ []*Expr, _ []*tree.Cursor) []*tree.Cursor {
+	return []*tree.Cursor{}
+}
+
+// Run ...
+func (EmptyOperator) Run(ev *Evaluator, args []*Expr) (*Response, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("empty operator expects 1 argument, received %d", len(args))
+	}
+
+	var emptyType string
+
+	switch args[0].Type {
+	case Literal:
+		var isString bool
+		emptyType, isString = args[0].Literal.(string)
+		if !isString {
+			return nil, fmt.Errorf("cannot interpret argument for empty operator")
+		}
+	case Reference:
+		emptyType = strings.TrimPrefix(args[0].Reference.String(), ".")
+	default:
+		return nil, fmt.Errorf("cannot interpret argument for empty operator")
+	}
+
+	var value interface{}
+	switch emptyType {
+	case "hash", "map":
+		value = map[string]interface{}{}
+	case "array", "list":
+		value = []interface{}{}
+	case "string":
+		value = ""
+	default:
+		return nil, fmt.Errorf("unknown type for empty operator: %s", emptyType)
+	}
+	return &Response{
+		Type:  Replace,
+		Value: value,
+	}, nil
+}
+
+func init() {
+	RegisterOp("empty", EmptyOperator{})
+}

--- a/operator_test.go
+++ b/operator_test.go
@@ -1558,6 +1558,21 @@ meta:
 			So(val, ShouldResemble, map[string]interface{}{})
 		})
 
+		Convey("throws an error with no args", func() {
+			r, err := op.Run(ev, []*Expr{})
+			So(r, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("throws an error with too many args", func() {
+			r, err := op.Run(ev, []*Expr{
+				ref("hash"),
+				ref("array"),
+			})
+			So(r, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+		})
+
 	})
 
 }

--- a/operator_test.go
+++ b/operator_test.go
@@ -1490,4 +1490,74 @@ meta:
 			So(r, ShouldBeNil)
 		})
 	})
+
+	Convey("empty operator", t, func() {
+		op := EmptyOperator{}
+		ev := &Evaluator{
+			Tree: YAML(
+				`---
+meta:
+  authorities: meep
+`),
+		}
+
+		//These three are with unquoted arguments (references)
+		Convey("can replace with a hash", func() {
+			r, err := op.Run(ev, []*Expr{
+				ref("hash"),
+			})
+			So(err, ShouldBeNil)
+			So(r, ShouldNotBeNil)
+			So(r.Type, ShouldEqual, Replace)
+			val, isHash := r.Value.(map[string]interface{})
+			So(isHash, ShouldBeTrue)
+			So(val, ShouldResemble, map[string]interface{}{})
+		})
+
+		Convey("can replace with an array", func() {
+			r, err := op.Run(ev, []*Expr{
+				ref("array"),
+			})
+			So(err, ShouldBeNil)
+			So(r, ShouldNotBeNil)
+			So(r.Type, ShouldEqual, Replace)
+			val, isArray := r.Value.([]interface{})
+			So(isArray, ShouldBeTrue)
+			So(val, ShouldResemble, []interface{}{})
+		})
+
+		Convey("can replace with an empty string", func() {
+			r, err := op.Run(ev, []*Expr{
+				ref("string"),
+			})
+			So(err, ShouldBeNil)
+			So(r, ShouldNotBeNil)
+			So(r.Type, ShouldEqual, Replace)
+			val, isString := r.Value.(string)
+			So(isString, ShouldBeTrue)
+			So(val, ShouldEqual, "")
+		})
+
+		Convey("throws an error for unrecognized types", func() {
+			r, err := op.Run(ev, []*Expr{
+				ref("void"),
+			})
+			So(r, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("works with string literals", func() {
+			r, err := op.Run(ev, []*Expr{
+				str("hash"),
+			})
+			So(err, ShouldBeNil)
+			So(r, ShouldNotBeNil)
+			So(r.Type, ShouldEqual, Replace)
+			val, isHash := r.Value.(map[string]interface{})
+			So(isHash, ShouldBeTrue)
+			So(val, ShouldResemble, map[string]interface{}{})
+		})
+
+	})
+
 }


### PR DESCRIPTION
It can be cumbersome to overwrite existing arrays/maps with empty objects, because the default behavior for spruce when merging over maps is to, well, merge. This is an operator aimed towards making this admittedly niche task more doable.