### PR TITLE
Join properly reports dependencies, taking into account elements of lists

### DIFF
--- a/assets/join/issue-155/deps.yml
+++ b/assets/join/issue-155/deps.yml
@@ -1,0 +1,14 @@
+---
+greeting: hello
+
+b:
+  - (( grab greeting ))
+  - world
+
+z:
+  - (( grab greeting ))
+  - bye
+
+output:
+  - (( join " " b ))
+  - (( join " " z ))

--- a/cmd/spruce/main_test.go
+++ b/cmd/spruce/main_test.go
@@ -692,6 +692,28 @@ quux: quux
 				})
 			})
 		})
+
+		Convey("Join operator works", func() {
+			Convey("when dependencies could cause improper evaluation order", func() {
+				os.Args = []string{"spruce", "merge", "../../assets/join/issue-155/deps.yml"}
+				stdout = ""
+				stderr = ""
+				main()
+				So(stderr, ShouldEqual, "")
+				So(stdout, ShouldEqual, `b:
+- hello
+- world
+greeting: hello
+output:
+- hello world
+- hello bye
+z:
+- hello
+- bye
+
+`)
+			})
+		})
 	})
 }
 

--- a/evaluator_test.go
+++ b/evaluator_test.go
@@ -2,12 +2,13 @@ package spruce
 
 import (
 	"bufio"
-	"github.com/smallfish/simpleyaml"
-	. "github.com/smartystreets/goconvey/convey"
-	"gopkg.in/yaml.v2"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/smallfish/simpleyaml"
+	. "github.com/smartystreets/goconvey/convey"
+	"gopkg.in/yaml.v2"
 )
 
 func TestEvaluator(t *testing.T) {
@@ -1465,6 +1466,64 @@ keys:
   - second
   - third
 
+#################################### (( join ... )) an array with (( grab ...))
+---
+greeting: hello
+
+z:
+- (( grab greeting ))
+- world
+
+output: (( join " " z ))
+---
+dataflow:
+- z.0: (( grab greeting ))
+- output: (( join " " z ))
+---
+greeting: hello
+output: hello world
+z:
+- hello
+- world
+#################################### (( join ... )) an array with several (( grab ...))s
+---
+greeting: hello
+greeting2: world
+
+z:
+- (( grab greeting ))
+- (( grab greeting2 ))
+
+output: (( join " " z ))
+---
+dataflow:
+- z.0: (( grab greeting ))
+- z.1: (( grab greeting2 ))
+- output: (( join " " z ))
+---
+greeting: hello
+greeting2: world
+output: hello world
+z:
+- hello
+- world
+#################################### (( join ... )) a string reference with a grab
+---
+greeting: hello
+z_one: (( grab greeting ))
+z_two: world
+output:
+- (( join " " z_one z_two ))
+---
+dataflow:
+- z_one: (( grab greeting ))
+- output.0: (( join " " z_one z_two ))
+---
+greeting: hello
+output:
+- hello world
+z_one: hello
+z_two: world
 `)
 	})
 

--- a/op_join.go
+++ b/op_join.go
@@ -59,17 +59,19 @@ func (JoinOperator) Dependencies(ev *Evaluator, args []*Expr, _ []*tree.Cursor) 
 		//must be a list or a string
 		switch list.(type) {
 		case []interface{}:
-			numObjs := len(list.([]interface{}))
-			//Make a cursor for every item in the list
-			for i := 0; i < numObjs; i++ {
-				//add an array index to the end of the cursor string and re-cursor-fy it
-				newCursor, err := tree.ParseCursor(fmt.Sprintf("%s.[%d]", finalCursor.Reference.String(), i))
-				if err != nil {
-					DEBUG("Failure when converting to array cursor. THIS IS A BUG.")
-					return []*tree.Cursor{}
-				}
-				deps = append(deps, newCursor)
+			//add .* to the end of the cursor so we can glob all the elements
+			globCursor, err := tree.ParseCursor(fmt.Sprintf("%s.*", finalCursor.Reference.String()))
+			if err != nil {
+				DEBUG("Could not parse cursor with '.*' appended. This is a BUG")
+				return []*tree.Cursor{}
 			}
+			//have the cursor library get all the subelements for us
+			subElements, err := globCursor.Glob(ev.Tree)
+			if err != nil {
+				DEBUG("Could not retrieve subelements at path '%s'. This may be a BUG.", arg.String())
+				return []*tree.Cursor{}
+			}
+			deps = append(deps, subElements...)
 		case string:
 			deps = append(deps, finalCursor.Reference)
 		default:
@@ -77,7 +79,6 @@ func (JoinOperator) Dependencies(ev *Evaluator, args []*Expr, _ []*tree.Cursor) 
 			return []*tree.Cursor{}
 		}
 	}
-	//TODO  REMOVE
 	DEBUG("Dependencies for (( join ... )):")
 	for i, dep := range deps {
 		DEBUG("\t#%d %s", i, dep.String())

--- a/operator_test.go
+++ b/operator_test.go
@@ -1498,7 +1498,6 @@ meta:
 			//TODO: Move this to a higher scope when more dependencies tests are added
 			shouldHaveDeps := func(actual interface{}, expected ...interface{}) string {
 				deps := actual.([]*tree.Cursor)
-				fmt.Printf("%+v", actual.([]*tree.Cursor))
 				paths := []string{}
 				for _, path := range expected {
 					normalizedPath, err := tree.ParseCursor(path.(string))


### PR DESCRIPTION
Begins to address #155 but there are likely more operators that need data flow fixed for that to be considered closed. This corrects the evaluation order for (( join ... )), so that now it should pull all the things in the correct order, all the time