### PR TITLE
More helpful error for when delete is followed by array objects

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -232,7 +232,7 @@ func (m *Merger) mergeArray(orig []interface{}, n []interface{}, node string) []
 				} else {
 					// Sanity check for delete operation, ensure no orphan entries follow the operator definition
 					if len(modificationDefinitions[i].list) > 0 {
-						m.Errors.Append(ansi.Errorf("@m{%s}: @R{unable to delete, orphan entries found after} @c{'%s: %s'}", node, key, name))
+						m.Errors.Append(ansi.Errorf("@m{%s}: @R{item in array directly after} @c{(( delete %s: \"%s\" ))} @r{must be one of commands 'append', 'prepend', 'delete', or 'insert'}", node, key, name))
 						return nil
 					}
 				}

--- a/merge.go
+++ b/merge.go
@@ -232,7 +232,7 @@ func (m *Merger) mergeArray(orig []interface{}, n []interface{}, node string) []
 				} else {
 					// Sanity check for delete operation, ensure no orphan entries follow the operator definition
 					if len(modificationDefinitions[i].list) > 0 {
-						m.Errors.Append(ansi.Errorf("@m{%s}: @R{item in array directly after} @c{(( delete %s: \"%s\" ))} @r{must be one of commands 'append', 'prepend', 'delete', or 'insert'}", node, key, name))
+						m.Errors.Append(ansi.Errorf("@m{%s}: @R{item in array directly after} @c{(( delete %s: \"%s\" ))} @r{must be one of the array operators 'append', 'prepend', 'delete', or 'insert'}", node, key, name))
 						return nil
 					}
 				}


### PR DESCRIPTION
No real behavior altered. Just more useful output. Looks like
```
→  go run cmd/spruce/main.go merge ~/sprtest.yml ~/sprtest2.yml
1 error(s) detected:
 - $.foo: item in array directly after (( delete name: "bar"' )) must be one of commands 'append', 'prepend', 'delete', or 'insert'
```