### PR TITLE
Ops can now be specified in lists even if the first item isn't an op

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,7 @@
 {
 	"ImportPath": "github.com/geofffranks/spruce",
-	"GoVersion": "go1.6",
+	"GoVersion": "go1.7",
+	"GodepVersion": "v74",
 	"Packages": [
 		"./..."
 	],
@@ -34,18 +35,18 @@
 		},
 		{
 			"ImportPath": "github.com/smartystreets/goconvey/convey",
-			"Comment": "1.5.0-386-geb2e83c",
-			"Rev": "eb2e83c1df892d2c9ad5a3c85672da30be585dfd"
+			"Comment": "1.6.2-6-g5db88ed",
+			"Rev": "5db88ed452e937f2fd557de6f4f1af7f2eabed0b"
 		},
 		{
 			"ImportPath": "github.com/smartystreets/goconvey/convey/gotest",
-			"Comment": "1.5.0-386-geb2e83c",
-			"Rev": "eb2e83c1df892d2c9ad5a3c85672da30be585dfd"
+			"Comment": "1.6.2-6-g5db88ed",
+			"Rev": "5db88ed452e937f2fd557de6f4f1af7f2eabed0b"
 		},
 		{
 			"ImportPath": "github.com/smartystreets/goconvey/convey/reporting",
-			"Comment": "1.5.0-386-geb2e83c",
-			"Rev": "eb2e83c1df892d2c9ad5a3c85672da30be585dfd"
+			"Comment": "1.6.2-6-g5db88ed",
+			"Rev": "5db88ed452e937f2fd557de6f4f1af7f2eabed0b"
 		},
 		{
 			"ImportPath": "github.com/starkandwayne/goutils/ansi",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/geofffranks/spruce",
-	"GoVersion": "go1.7",
+	"GoVersion": "go1.6",
 	"GodepVersion": "v74",
 	"Packages": [
 		"./..."

--- a/merge.go
+++ b/merge.go
@@ -372,6 +372,8 @@ func shouldInlineMergeArray(obj []interface{}) bool {
 // array operations to apply to which entries. The first object in the returned
 // will always represent the default merge behavior.
 func getArrayModifications(obj []interface{}) []ModificationDefinition {
+
+	//Starts with an entry representing the default merge behavior
 	result := []ModificationDefinition{ModificationDefinition{defaultMerge: true}}
 	//easy shortcircuit
 	if len(obj) == 0 {
@@ -384,8 +386,6 @@ func getArrayModifications(obj []interface{}) []ModificationDefinition {
 	insertByNameRegEx := regexp.MustCompile("^\\Q((\\E\\s*insert\\s+(after|before)\\s+([^ ]+)?\\s*\"(.+)\"\\s*\\Q))\\E$")
 	deleteByIdxRegEx := regexp.MustCompile("^\\Q((\\E\\s*delete\\s+(\\d+)\\s*\\Q))\\E$")
 	deleteByNameRegEx := regexp.MustCompile("^\\Q((\\E\\s*delete\\s+([^ ]+)?\\s*\"(.+)\"\\s*\\Q))\\E$")
-
-	//Represents the default merging behavior if the user doesn't specify anything
 
 	for _, entry := range obj {
 		e, isString := entry.(string)

--- a/merge_test.go
+++ b/merge_test.go
@@ -1,6 +1,7 @@
 package spruce
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -143,288 +144,204 @@ func TestShouldKeyMergeArrayOfHashes(t *testing.T) {
 	})
 }
 
-func TestShouldInsertIntoArray(t *testing.T) {
-	Convey("We should insert into arrays based on append/prepend, index, and key/name", t, func() {
-		Convey("Append related test cases", func() {
-			Convey("If the element is a string with the right append token", func() {
-				result, _ := shouldModifyArray([]interface{}{"(( append ))", "stuff"})
-				So(result, ShouldBeTrue)
-			})
-			Convey("But not if the element is not a string", func() {
-				result, _ := shouldModifyArray([]interface{}{42})
-				So(result, ShouldBeFalse)
-			})
-			Convey("But not if the slice has no elements", func() {
-				result, _ := shouldModifyArray([]interface{}{})
-				So(result, ShouldBeFalse)
-			})
-			Convey("Is whitespace agnostic", func() {
-				Convey("No surrounding whitespace", func() {
-					yes, _ := shouldModifyArray([]interface{}{"((append))"})
-					So(yes, ShouldBeTrue)
+func TestGetArrayModifications(t *testing.T) {
+	shouldInsertAt := func(actual interface{}, expIndex ...interface{}) string {
+		return ShouldEqual(actual.(ModificationDefinition).index, expIndex[0].(int))
+	}
+
+	shouldBeAppend := func(actual interface{}, _ ...interface{}) string {
+		return shouldInsertAt(actual, -1)
+	}
+
+	shouldBePrepend := func(actual interface{}, _ ...interface{}) string {
+		return shouldInsertAt(actual, 0)
+	}
+
+	shouldBeDelete := func(actual interface{}, _ ...interface{}) string {
+		if !actual.(ModificationDefinition).delete {
+			return "Result doesn't have marker for delete operation"
+		}
+		return ""
+	}
+
+	Convey("Should recognize string patterns for", t, func() {
+
+		Convey("(( append ))", func() {
+			//append test cases go here
+			for _, input := range []string{
+				"(( append ))",
+				"((append))",
+				"((	append	))",
+				"((  append  ))",
+				"((     append))",
+			} {
+				Convey(fmt.Sprintf("with case %s", input), func() {
+					results := getArrayModifications([]interface{}{input})
+					So(results, ShouldHaveLength, 2)
+					So(results[1], shouldBeAppend)
 				})
-				Convey("Surrounding tabs", func() {
-					yes, _ := shouldModifyArray([]interface{}{"((	append	))"})
-					So(yes, ShouldBeTrue)
-				})
-				Convey("Multiple surrounding whitespaces", func() {
-					yes, _ := shouldModifyArray([]interface{}{"((  append  ))"})
-					So(yes, ShouldBeTrue)
-				})
-			})
+			}
 		})
 
-		Convey("Prepend related test cases", func() {
-			Convey("If the element is a string with the right prepend token", func() {
-				result, _ := shouldModifyArray([]interface{}{"(( prepend ))", "stuff"})
-				So(result, ShouldBeTrue)
-			})
-			Convey("But not if the element is not a string", func() {
-				result, _ := shouldModifyArray([]interface{}{42})
-				So(result, ShouldBeFalse)
-			})
-			Convey("But not if the slice has no elements", func() {
-				result, _ := shouldModifyArray([]interface{}{})
-				So(result, ShouldBeFalse)
-			})
-			Convey("Is whitespace agnostic", func() {
-				Convey("No surrounding whitespace", func() {
-					yes, _ := shouldModifyArray([]interface{}{"((prepend))"})
-					So(yes, ShouldBeTrue)
+		Convey("(( prepend ))", func() {
+			//prepend test cases go here
+			for _, input := range []string{
+				"(( prepend ))",
+				"((prepend))",
+				"((	prepend	))",
+				"((  prepend  ))",
+				"((     prepend))",
+			} {
+				Convey(fmt.Sprintf("with case %s", input), func() {
+					results := getArrayModifications([]interface{}{input})
+					So(results, ShouldHaveLength, 2)
+					So(results[1], shouldBePrepend)
 				})
-				Convey("Surrounding tabs", func() {
-					yes, _ := shouldModifyArray([]interface{}{"((	prepend	))"})
-					So(yes, ShouldBeTrue)
-				})
-				Convey("Multiple surrounding whitespaces", func() {
-					yes, _ := shouldModifyArray([]interface{}{"((  prepend  ))"})
-					So(yes, ShouldBeTrue)
-				})
-			})
+			}
 		})
 
-		Convey("Insert with index related test cases", func() {
-			Convey("If insert token with after and index is found", func() {
-				result, modificationDefinitions := shouldModifyArray([]interface{}{"(( insert after 0 ))", "stuff"})
-				So(result, ShouldBeTrue)
-				So(len(modificationDefinitions), ShouldEqual, 1)
-				So(modificationDefinitions[0].relative, ShouldEqual, "after")
-				So(modificationDefinitions[0].index, ShouldEqual, 0)
-			})
-
-			Convey("If insert token with before and index is found", func() {
-				result, modificationDefinitions := shouldModifyArray([]interface{}{"(( insert before 0 ))", "stuff"})
-				So(result, ShouldBeTrue)
-				So(len(modificationDefinitions), ShouldEqual, 1)
-				So(modificationDefinitions[0].relative, ShouldEqual, "before")
-				So(modificationDefinitions[0].index, ShouldEqual, 0)
-			})
-
-			Convey("If insert token with after and index is found independent of missing whitespaces", func() {
-				result, modificationDefinitions := shouldModifyArray([]interface{}{"((insert after 0))", "stuff"})
-				So(result, ShouldBeTrue)
-				So(len(modificationDefinitions), ShouldEqual, 1)
-				So(modificationDefinitions[0].relative, ShouldEqual, "after")
-				So(modificationDefinitions[0].index, ShouldEqual, 0)
-			})
-
-			Convey("If insert token with after and index is found with a lot of additional whitespaces", func() {
-				result, modificationDefinitions := shouldModifyArray([]interface{}{"((  insert   after   0  ))", "stuff"})
-				So(result, ShouldBeTrue)
-				So(len(modificationDefinitions), ShouldEqual, 1)
-				So(modificationDefinitions[0].relative, ShouldEqual, "after")
-				So(modificationDefinitions[0].index, ShouldEqual, 0)
-			})
-
-			Convey("But not if index is obviously out of bounds", func() {
-				result, modificationDefinitions := shouldModifyArray([]interface{}{"(( insert before -1 ))", "stuff"})
-				So(result, ShouldBeFalse)
-				So(modificationDefinitions, ShouldBeNil)
-			})
+		Convey("(( insert ... ))", func() {
+			for _, rel := range []string{"before", "after"} {
+				for _, index := range []int{0, 10, 100} {
+					//index based insert cases go here
+					for _, input := range []string{
+						fmt.Sprintf("(( insert %s %d ))", rel, index),
+						fmt.Sprintf("(( insert %s	 %d ))", rel, index),
+						fmt.Sprintf("(( insert	 %s %d ))", rel, index),
+						fmt.Sprintf("(( insert   %s   %d ))", rel, index),
+						fmt.Sprintf("((   insert %s %d ))", rel, index),
+						fmt.Sprintf("(( insert %s %d   ))", rel, index),
+						fmt.Sprintf("((    insert %s %d ))", rel, index),
+						fmt.Sprintf("((   insert   %s   %d	 ))", rel, index),
+					} {
+						Convey(fmt.Sprintf("with case %s", input), func() {
+							results := getArrayModifications([]interface{}{input})
+							So(results, ShouldHaveLength, 2)
+							So(results[1], shouldInsertAt, index)
+							So(results[1].relative, ShouldEqual, rel)
+						})
+					}
+				}
+				for _, key := range []string{"", "foo"} {
+					//name based insert cases go here
+					for _, input := range []string{
+						fmt.Sprintf(`(( insert %s %s "spruce" ))`, rel, key),
+						fmt.Sprintf(`(( insert %s %s	 "spruce" ))`, rel, key),
+						fmt.Sprintf(`(( insert	 %s %s "spruce" ))`, rel, key),
+						fmt.Sprintf(`(( insert   %s %s   "spruce" ))`, rel, key),
+						fmt.Sprintf(`((   insert %s %s "spruce" ))`, rel, key),
+						fmt.Sprintf(`(( insert %s %s "spruce"   ))`, rel, key),
+						fmt.Sprintf(`((    insert %s %s "spruce" ))`, rel, key),
+						fmt.Sprintf(`(( insert %s    %s "spruce" ))`, rel, key),
+						fmt.Sprintf(`((    insert    %s    %s     "spruce"   ))`, rel, key),
+						fmt.Sprintf(`((   insert   %s %s   "spruce"	 ))`, rel, key),
+					} {
+						Convey(fmt.Sprintf("with case %s", input), func() {
+							results := getArrayModifications([]interface{}{input})
+							So(results, ShouldHaveLength, 2)
+							So(results[1].name, ShouldEqual, "spruce")
+							testKey := key
+							if testKey == "" {
+								testKey = "name"
+							}
+							So(results[1].key, ShouldEqual, testKey)
+							So(results[1].relative, ShouldEqual, rel)
+						})
+					}
+				}
+			}
 		})
 
-		Convey("Insert with key/name related test cases", func() {
-			Convey("If insert token with after, and insertion-name was found", func() {
-				result, modificationDefinitions := shouldModifyArray([]interface{}{"(( insert after \"nats\" ))", "stuff"})
-				So(result, ShouldBeTrue)
-				So(modificationDefinitions, ShouldNotBeNil)
-				So(len(modificationDefinitions), ShouldEqual, 1)
-				So(modificationDefinitions[0].relative, ShouldEqual, "after")
-				So(modificationDefinitions[0].key, ShouldEqual, "name")
-				So(modificationDefinitions[0].name, ShouldEqual, "nats")
-			})
+		Convey("(( delete ... ))", func() {
+			for _, key := range []string{"", "foo"} {
+				//name based delete cases go here
+				for _, input := range []string{
+					fmt.Sprintf(`(( delete %s "spruce" ))`, key),
+					fmt.Sprintf(`(( delete %s	 "spruce" ))`, key),
+					fmt.Sprintf(`(( delete	 %s "spruce" ))`, key),
+					fmt.Sprintf(`(( delete   %s   "spruce" ))`, key),
+					fmt.Sprintf(`((   delete %s "spruce" ))`, key),
+					fmt.Sprintf(`(( delete %s "spruce"   ))`, key),
+					fmt.Sprintf(`(( delete %s "spruce"    ))`, key),
+					fmt.Sprintf(`((    delete %s "spruce" ))`, key),
+					fmt.Sprintf(`((   delete   %s   "spruce"	 ))`, key),
+				} {
+					Convey(fmt.Sprintf("with case %s", input), func() {
+						results := getArrayModifications([]interface{}{input})
+						So(results, ShouldHaveLength, 2)
+						So(results[1].name, ShouldEqual, "spruce")
+						testKey := key
+						if testKey == "" {
+							testKey = "name"
+						}
+						So(results[1].key, ShouldEqual, testKey)
+					})
+				}
+			}
 
-			Convey("If insert token with after, key-name and insertion-name was found", func() {
-				result, modificationDefinitions := shouldModifyArray([]interface{}{"(( insert after name \"nats\" ))", "stuff"})
-				So(result, ShouldBeTrue)
-				So(modificationDefinitions, ShouldNotBeNil)
-				So(len(modificationDefinitions), ShouldEqual, 1)
-				So(modificationDefinitions[0].relative, ShouldEqual, "after")
-				So(modificationDefinitions[0].key, ShouldEqual, "name")
-				So(modificationDefinitions[0].name, ShouldEqual, "nats")
-			})
-
-			Convey("If insert token with before, another custom key-name and insertion-name was found", func() {
-				result, modificationDefinitions := shouldModifyArray([]interface{}{"(( insert before id \"ccdb\" ))", "stuff"})
-				So(result, ShouldBeTrue)
-				So(modificationDefinitions, ShouldNotBeNil)
-				So(len(modificationDefinitions), ShouldEqual, 1)
-				So(modificationDefinitions[0].relative, ShouldEqual, "before")
-				So(modificationDefinitions[0].key, ShouldEqual, "id")
-				So(modificationDefinitions[0].name, ShouldEqual, "ccdb")
-			})
-
-			Convey("If insert token with after, key-name and insertion-name was found without additional whitespaces", func() {
-				result, modificationDefinitions := shouldModifyArray([]interface{}{"((insert after name \"nats\"))", "stuff"})
-				So(result, ShouldBeTrue)
-				So(modificationDefinitions, ShouldNotBeNil)
-				So(len(modificationDefinitions), ShouldEqual, 1)
-				So(modificationDefinitions[0].relative, ShouldEqual, "after")
-				So(modificationDefinitions[0].key, ShouldEqual, "name")
-				So(modificationDefinitions[0].name, ShouldEqual, "nats")
-			})
-
-			Convey("If insert token with after, key-name and insertion-name was found with additional whitespaces", func() {
-				result, modificationDefinitions := shouldModifyArray([]interface{}{"((   insert   after     name   \"nats\"   ))", "stuff"})
-				So(result, ShouldBeTrue)
-				So(modificationDefinitions, ShouldNotBeNil)
-				So(len(modificationDefinitions), ShouldEqual, 1)
-				So(modificationDefinitions[0].relative, ShouldEqual, "after")
-				So(modificationDefinitions[0].key, ShouldEqual, "name")
-				So(modificationDefinitions[0].name, ShouldEqual, "nats")
-			})
-
-			Convey("If insert token with after, key-name and insertion-name was found, but the list is empty", func() {
-				result, modificationDefinitions := shouldModifyArray([]interface{}{"(( insert after name \"nats\" ))"})
-				So(result, ShouldBeTrue)
-				So(modificationDefinitions, ShouldNotBeNil)
-				So(len(modificationDefinitions), ShouldEqual, 1)
-				So(modificationDefinitions[0].relative, ShouldEqual, "after")
-				So(modificationDefinitions[0].key, ShouldEqual, "name")
-				So(modificationDefinitions[0].name, ShouldEqual, "nats")
-				So(modificationDefinitions[0].list, ShouldBeNil)
-			})
-
-			Convey("If there are multiple insert token with after/before, different key names, and names (only technical usecase)", func() {
-				result, modificationDefinitions := shouldModifyArray([]interface{}{
-					"(( insert after name \"nats\" ))",
-					"stuff1",
-					"stuff2",
-					"stuff3",
-					"(( insert before id \"consul\" ))",
-					"stuffX1",
-					"stuffX2",
-				})
-				So(result, ShouldBeTrue)
-				So(modificationDefinitions, ShouldNotBeNil)
-				So(len(modificationDefinitions), ShouldEqual, 2)
-				So(modificationDefinitions[0].relative, ShouldEqual, "after")
-				So(modificationDefinitions[0].key, ShouldEqual, "name")
-				So(modificationDefinitions[0].name, ShouldEqual, "nats")
-				So(modificationDefinitions[0].list, ShouldResemble, []interface{}{"stuff1", "stuff2", "stuff3"})
-				So(modificationDefinitions[1].relative, ShouldEqual, "before")
-				So(modificationDefinitions[1].key, ShouldEqual, "id")
-				So(modificationDefinitions[1].name, ShouldEqual, "consul")
-				So(modificationDefinitions[1].list, ShouldResemble, []interface{}{"stuffX1", "stuffX2"})
-			})
-
-			Convey("But not if the magic token is not specified", func() {
-				result, modificationDefinitions := shouldModifyArray([]interface{}{"not a magic token", "stuff"})
-				So(result, ShouldBeFalse)
-				So(modificationDefinitions, ShouldBeNil)
-			})
+			for _, index := range []int{0, 10, 100} {
+				//name based delete cases go here
+				for _, input := range []string{
+					fmt.Sprintf(`(( delete %d ))`, index),
+					fmt.Sprintf(`(( delete     %d ))`, index),
+					fmt.Sprintf(`((   delete %d ))`, index),
+					fmt.Sprintf(`(( delete %d   ))`, index),
+					fmt.Sprintf(`((   delete     %d	 ))`, index),
+				} {
+					Convey(fmt.Sprintf("with case %s", input), func() {
+						results := getArrayModifications([]interface{}{input})
+						So(results, ShouldHaveLength, 2)
+						So(results[1].index, ShouldEqual, index)
+						So(results[1], shouldBeDelete)
+					})
+				}
+			}
 		})
+	})
 
-		Convey("Delete with index related test cases", func() {
-			Convey("If delete token with index is found", func() {
-				result, modificationDefinitions := shouldModifyArray([]interface{}{"(( delete 0 ))", "stuff"})
-				So(result, ShouldBeTrue)
-				So(len(modificationDefinitions), ShouldEqual, 1)
-				So(modificationDefinitions[0].index, ShouldEqual, 0)
-			})
+	Convey("Don't return an insert if index is obviously out of bounds", t, func() {
+		results := getArrayModifications([]interface{}{"(( insert before -1 ))", "stuff"})
+		So(results, ShouldHaveLength, 1) //Just the default merge
+		So(results[0].defaultMerge, ShouldBeTrue)
+	})
 
-			Convey("If delete token with another index is found", func() {
-				result, modificationDefinitions := shouldModifyArray([]interface{}{"(( delete 2 ))", "stuff"})
-				So(result, ShouldBeTrue)
-				So(len(modificationDefinitions), ShouldEqual, 1)
-				So(modificationDefinitions[0].index, ShouldEqual, 2)
-			})
-
-			Convey("If delete token with index is found independent of missing whitespaces", func() {
-				result, modificationDefinitions := shouldModifyArray([]interface{}{"((delete 0))", "stuff"})
-				So(result, ShouldBeTrue)
-				So(len(modificationDefinitions), ShouldEqual, 1)
-				So(modificationDefinitions[0].index, ShouldEqual, 0)
-			})
-
-			Convey("If delete token with index is found with a lot of additional whitespaces", func() {
-				result, modificationDefinitions := shouldModifyArray([]interface{}{"((  delete   0  ))", "stuff"})
-				So(result, ShouldBeTrue)
-				So(len(modificationDefinitions), ShouldEqual, 1)
-				So(modificationDefinitions[0].index, ShouldEqual, 0)
-			})
-
-			Convey("But not if index is obviously out of bounds", func() {
-				result, modificationDefinitions := shouldModifyArray([]interface{}{"(( delete -1 ))", "stuff"})
-				So(result, ShouldBeFalse)
-				So(modificationDefinitions, ShouldBeNil)
-			})
+	Convey("If there are multiple insert token with after/before, different key names, and names (only technical usecase)", t, func() {
+		results := getArrayModifications([]interface{}{
+			"(( insert after name \"nats\" ))",
+			"stuff1",
+			"stuff2",
+			"stuff3",
+			"(( insert before id \"consul\" ))",
+			"stuffX1",
+			"stuffX2",
 		})
+		So(results, ShouldNotBeNil)
+		So(len(results), ShouldEqual, 3)
+		So(results[1].relative, ShouldEqual, "after")
+		So(results[1].key, ShouldEqual, "name")
+		So(results[1].name, ShouldEqual, "nats")
+		So(results[1].list, ShouldResemble, []interface{}{"stuff1", "stuff2", "stuff3"})
+		So(results[2].relative, ShouldEqual, "before")
+		So(results[2].key, ShouldEqual, "id")
+		So(results[2].name, ShouldEqual, "consul")
+		So(results[2].list, ShouldResemble, []interface{}{"stuffX1", "stuffX2"})
+	})
 
-		Convey("We should delete into arrays based on key/name", func() {
-			Convey("Delete with key/name related test cases", func() {
-				Convey("If delete token with delete-name was found", func() {
-					result, deleteDefinitions := shouldModifyArray([]interface{}{"(( delete \"nats\" ))", "stuff"})
-					So(result, ShouldBeTrue)
-					So(deleteDefinitions, ShouldNotBeNil)
-					So(len(deleteDefinitions), ShouldEqual, 1)
-					So(deleteDefinitions[0].key, ShouldEqual, "name")
-					So(deleteDefinitions[0].name, ShouldEqual, "nats")
-				})
+	Convey("Only default merge if no operators given", t, func() {
+		results := getArrayModifications([]interface{}{"not a magic token", "stuff"})
+		So(results, ShouldHaveLength, 1)
+		So(results[0].defaultMerge, ShouldBeTrue)
+	})
 
-				Convey("If delete token with key-name and delete-name was found", func() {
-					result, deleteDefinitions := shouldModifyArray([]interface{}{"(( delete name \"nats\" ))", "stuff"})
-					So(result, ShouldBeTrue)
-					So(deleteDefinitions, ShouldNotBeNil)
-					So(len(deleteDefinitions), ShouldEqual, 1)
-					So(deleteDefinitions[0].key, ShouldEqual, "name")
-					So(deleteDefinitions[0].name, ShouldEqual, "nats")
-				})
-
-				Convey("If delete token with another custom key-name and delete-name was found", func() {
-					result, deleteDefinitions := shouldModifyArray([]interface{}{"(( delete id \"ccdb\" ))", "stuff"})
-					So(result, ShouldBeTrue)
-					So(deleteDefinitions, ShouldNotBeNil)
-					So(len(deleteDefinitions), ShouldEqual, 1)
-					So(deleteDefinitions[0].key, ShouldEqual, "id")
-					So(deleteDefinitions[0].name, ShouldEqual, "ccdb")
-				})
-
-				Convey("If delete token with key-name and delete-name was found without additional whitespaces", func() {
-					result, deleteDefinitions := shouldModifyArray([]interface{}{"((delete name \"nats\"))", "stuff"})
-					So(result, ShouldBeTrue)
-					So(deleteDefinitions, ShouldNotBeNil)
-					So(len(deleteDefinitions), ShouldEqual, 1)
-					So(deleteDefinitions[0].key, ShouldEqual, "name")
-					So(deleteDefinitions[0].name, ShouldEqual, "nats")
-				})
-
-				Convey("If delete token with key-name and delete-name was found with additional whitespaces", func() {
-					result, deleteDefinitions := shouldModifyArray([]interface{}{"((   delete        name   \"nats\"   ))", "stuff"})
-					So(result, ShouldBeTrue)
-					So(deleteDefinitions, ShouldNotBeNil)
-					So(len(deleteDefinitions), ShouldEqual, 1)
-					So(deleteDefinitions[0].key, ShouldEqual, "name")
-					So(deleteDefinitions[0].name, ShouldEqual, "nats")
-				})
-
-				Convey("But not if the magic token is not specified", func() {
-					result, deleteDefinitions := shouldModifyArray([]interface{}{"not a magic token", "stuff"})
-					So(result, ShouldBeFalse)
-					So(deleteDefinitions, ShouldBeNil)
-				})
-			})
-		})
+	Convey("Can specify operators without one at the 0th index", t, func() {
+		results := getArrayModifications([]interface{}{"foo", "(( append ))", "stuff"})
+		So(results, ShouldHaveLength, 2)
+		So(results[0].defaultMerge, ShouldBeTrue)
+		So(results[1], shouldBeAppend)
+		So(results[0].list, ShouldHaveLength, 1)
+		So(results[1].list, ShouldHaveLength, 1)
+		So(results[0].list[0], ShouldEqual, "foo")
+		So(results[1].list[0], ShouldEqual, "stuff")
 	})
 }
 

--- a/vendor/github.com/smartystreets/goconvey/LICENSE.md
+++ b/vendor/github.com/smartystreets/goconvey/LICENSE.md
@@ -1,21 +1,21 @@
-Copyright (c) 2014 SmartyStreets, LLC
+Copyright (c) 2016 SmartyStreets, LLC
 
-Permission is hereby granted, free of charge, to any person obtaining a copy 
-of this software and associated documentation files (the "Software"), to deal 
-in the Software without restriction, including without limitation the rights 
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
-copies of the Software, and to permit persons to whom the Software is 
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all 
+The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 NOTE: Various optional and subordinate components carry their own licensing

--- a/vendor/github.com/smartystreets/goconvey/convey/assertions.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/assertions.go
@@ -26,12 +26,15 @@ var (
 	ShouldBeBetweenOrEqual       = assertions.ShouldBeBetweenOrEqual
 	ShouldNotBeBetweenOrEqual    = assertions.ShouldNotBeBetweenOrEqual
 
-	ShouldContain    = assertions.ShouldContain
-	ShouldNotContain = assertions.ShouldNotContain
-	ShouldBeIn       = assertions.ShouldBeIn
-	ShouldNotBeIn    = assertions.ShouldNotBeIn
-	ShouldBeEmpty    = assertions.ShouldBeEmpty
-	ShouldNotBeEmpty = assertions.ShouldNotBeEmpty
+	ShouldContain       = assertions.ShouldContain
+	ShouldNotContain    = assertions.ShouldNotContain
+	ShouldContainKey    = assertions.ShouldContainKey
+	ShouldNotContainKey = assertions.ShouldNotContainKey
+	ShouldBeIn          = assertions.ShouldBeIn
+	ShouldNotBeIn       = assertions.ShouldNotBeIn
+	ShouldBeEmpty       = assertions.ShouldBeEmpty
+	ShouldNotBeEmpty    = assertions.ShouldNotBeEmpty
+	ShouldHaveLength    = assertions.ShouldHaveLength
 
 	ShouldStartWith           = assertions.ShouldStartWith
 	ShouldNotStartWith        = assertions.ShouldNotStartWith

--- a/vendor/github.com/smartystreets/goconvey/convey/doc.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/doc.go
@@ -3,6 +3,8 @@
 // packages from this project as they serve internal purposes.
 package convey
 
+import "github.com/smartystreets/goconvey/convey/reporting"
+
 ////////////////////////////////// suite //////////////////////////////////
 
 // C is the Convey context which you can optionally obtain in your action
@@ -190,4 +192,27 @@ func Println(items ...interface{}) (written int, err error) {
 // output is aligned with the corresponding scopes in the web UI.
 func Printf(format string, items ...interface{}) (written int, err error) {
 	return mustGetCurrentContext().Printf(format, items...)
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+// SuppressConsoleStatistics prevents automatic printing of console statistics.
+// Calling PrintConsoleStatistics explicitly will force printing of statistics.
+func SuppressConsoleStatistics() {
+	reporting.SuppressConsoleStatistics()
+}
+
+// ConsoleStatistics may be called at any time to print assertion statistics.
+// Generally, the best place to do this would be in a TestMain function,
+// after all tests have been run. Something like this:
+//
+// func TestMain(m *testing.M) {
+//     convey.SuppressConsoleStatistics()
+//     result := m.Run()
+//     convey.PrintConsoleStatistics()
+//     os.Exit(result)
+// }
+//
+func PrintConsoleStatistics() {
+	reporting.PrintConsoleStatistics()
 }

--- a/vendor/github.com/smartystreets/goconvey/convey/gotest/utils.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/gotest/utils.go
@@ -4,18 +4,9 @@
 package gotest
 
 import (
-	"fmt"
 	"runtime"
 	"strings"
 )
-
-func FormatExternalFileAndLine() string {
-	file, line, _ := ResolveExternalCaller()
-	if line == -1 {
-		return "<unknown caller!>" // panic?
-	}
-	return fmt.Sprintf("%s:%d", file, line)
-}
 
 func ResolveExternalCaller() (file string, line int, name string) {
 	var caller_id uintptr
@@ -23,7 +14,7 @@ func ResolveExternalCaller() (file string, line int, name string) {
 
 	for x := 0; x < callers; x++ {
 		caller_id, file, line, _ = runtime.Caller(x)
-		if strings.HasSuffix(file, "_test.go") {
+		if strings.HasSuffix(file, "_test.go") || strings.HasSuffix(file, "_tests.go") {
 			name = runtime.FuncForPC(caller_id).Name()
 			return
 		}

--- a/vendor/github.com/smartystreets/goconvey/convey/init.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/init.go
@@ -18,9 +18,9 @@ func init() {
 }
 
 func declareFlags() {
-	flag.BoolVar(&json, "json", false, "When true, emits results in JSON blocks. Default: 'false'")
-	flag.BoolVar(&silent, "silent", false, "When true, all output from GoConvey is suppressed.")
-	flag.BoolVar(&story, "story", false, "When true, emits story output, otherwise emits dot output. When not provided, this flag mirros the value of the '-test.v' flag")
+	flag.BoolVar(&json, "convey-json", false, "When true, emits results in JSON blocks. Default: 'false'")
+	flag.BoolVar(&silent, "convey-silent", false, "When true, all output from GoConvey is suppressed.")
+	flag.BoolVar(&story, "convey-story", false, "When true, emits story output, otherwise emits dot output. When not provided, this flag mirros the value of the '-test.v' flag")
 
 	if noStoryFlagProvided() {
 		story = verboseEnabled
@@ -34,14 +34,19 @@ func noStoryFlagProvided() bool {
 }
 
 func buildReporter() reporting.Reporter {
+	selectReporter := os.Getenv("GOCONVEY_REPORTER")
+
 	switch {
 	case testReporter != nil:
 		return testReporter
-	case json:
+	case json || selectReporter == "json":
 		return reporting.BuildJsonReporter()
-	case silent:
+	case silent || selectReporter == "silent":
 		return reporting.BuildSilentReporter()
-	case story:
+	case selectReporter == "dot":
+		// Story is turned on when verbose is set, so we need to check for dot reporter first.
+		return reporting.BuildDotReporter()
+	case story || selectReporter == "story":
 		return reporting.BuildStoryReporter()
 	default:
 		return reporting.BuildDotReporter()

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/init.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/init.go
@@ -1,14 +1,13 @@
 package reporting
 
 import (
-	"fmt"
 	"os"
 	"runtime"
 	"strings"
 )
 
 func init() {
-	if !isXterm() {
+	if !isColorableTerminal() {
 		monochrome()
 	}
 
@@ -43,7 +42,7 @@ func BuildSilentReporter() Reporter {
 	out := NewPrinter(NewConsole())
 	return NewReporters(
 		NewGoTestReporter(),
-		NewProblemReporter(out))
+		NewSilentProblemReporter(out))
 }
 
 var (
@@ -69,6 +68,9 @@ var (
 
 var consoleStatistics = NewStatisticsReporter(NewPrinter(NewConsole()))
 
+func SuppressConsoleStatistics() { consoleStatistics.Suppress() }
+func PrintConsoleStatistics()    { consoleStatistics.PrintSummary() }
+
 // QuiteMode disables all console output symbols. This is only meant to be used
 // for tests that are internal to goconvey where the output is distracting or
 // otherwise not needed in the test output.
@@ -80,10 +82,8 @@ func monochrome() {
 	greenColor, yellowColor, redColor, resetColor = "", "", "", ""
 }
 
-func isXterm() bool {
-	env := fmt.Sprintf("%v", os.Environ())
-	return strings.Contains(env, " TERM=isXterm") ||
-		strings.Contains(env, " TERM=xterm")
+func isColorableTerminal() bool {
+	return strings.Contains(os.Getenv("TERM"), "color")
 }
 
 // This interface allows us to pass the *testing.T struct

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/problems.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/problems.go
@@ -3,6 +3,7 @@ package reporting
 import "fmt"
 
 type problem struct {
+	silent   bool
 	out      *Printer
 	errors   []*AssertionResult
 	failures []*AssertionResult
@@ -28,9 +29,13 @@ func (self *problem) EndStory() {
 	self.prepareForNextStory()
 }
 func (self *problem) show(display func(), color string) {
-	fmt.Print(color)
+	if !self.silent {
+		fmt.Print(color)
+	}
 	display()
-	fmt.Print(resetColor)
+	if !self.silent {
+		fmt.Print(resetColor)
+	}
 	self.out.Dedent()
 }
 func (self *problem) showErrors() {
@@ -62,6 +67,13 @@ func NewProblemReporter(out *Printer) *problem {
 	self.prepareForNextStory()
 	return self
 }
+
+func NewSilentProblemReporter(out *Printer) *problem {
+	self := NewProblemReporter(out)
+	self.silent = true
+	return self
+}
+
 func (self *problem) prepareForNextStory() {
 	self.errors = []*AssertionResult{}
 	self.failures = []*AssertionResult{}

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/reports.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/reports.go
@@ -76,10 +76,12 @@ func removePackagePath(name string) string {
 
 /////////////////// FailureView ////////////////////////
 
+// This struct is also declared in github.com/smartystreets/assertions.
+// The json struct tags should be equal in both declarations.
 type FailureView struct {
-	Message  string
-	Expected string
-	Actual   string
+	Message  string `json:"Message"`
+	Expected string `json:"Expected"`
+	Actual   string `json:"Actual"`
 }
 
 ////////////////////AssertionResult //////////////////////


### PR DESCRIPTION
Fixes a bug where the iteration through the list in search of ops would error out if the first item wasn't an operation, thus causing any later ops to be ignored.

To do this, now the first item returned from getArrayModifications (previously shouldModifyArray) represents the default merge behavior, as if no ops were specified. This maintains the existing default behavior while fixing this bug. With this change, it made sense to remove the boolean from the function.

Because the function signature was changed, all the tests also needed to be changed. I moved many of the tests into an iterative array model that should be easier to modify, and is also more thorough (and condensed!). The tests that weren't covered by that were updated to reflect the new function contract. Also, a couple new tests were added to check the new functionality that this PR addresses in the first place.