### PR TITLE
Adding a "cherry-picking" feature to Spruce

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,14 @@ or you can use the `(( prune ))` operator:
 key_to_prune: (( prune ))
 ```
 
+If you actually want to prune everything but one or two paths from your YAML, you can use the `--cherry-pick` flag to only select what you want to have in the end:<br>
+
+```
+spruce merge --cherry-pick jobs --cherry-pick properties file1.yml file2.yml
+```
+
+The `--cherry-pick` flag can be used in combination with the `--prune` flag as long as you do not prune the exact path you are about to cherry-pick.
+
 ### Referencing Other Data
 
 Need to reference existing data in your datastructure? No problem! `spruce` will wait until

--- a/assets/cherry-pick/fileA.yml
+++ b/assets/cherry-pick/fileA.yml
@@ -1,0 +1,17 @@
+meta:
+  some:
+    deep:
+      structure:
+        maplist:
+          keyA: valueA
+
+releases:
+- name: vb
+
+jobs:
+- name: vb
+
+properties:
+  vb:
+    id: 74a03820-3f81-45ca-afd5-d7d57b947ff1
+    flags: auth,block,read-only

--- a/assets/cherry-pick/fileB.yml
+++ b/assets/cherry-pick/fileB.yml
@@ -1,0 +1,18 @@
+meta:
+  some:
+    deep:
+      structure:
+        maplist:
+          keyB: valueB
+        ignoreme: foobar
+
+releases:
+- name: hahn
+
+jobs:
+- name: hahn
+
+properties:
+  hahn:
+    id: b503e54a-c872-4643-a09c-5480c5940d0c
+    flags: open

--- a/assets/cherry-pick/id-based-list.yml
+++ b/assets/cherry-pick/id-based-list.yml
@@ -1,0 +1,11 @@
+list:
+- id: one
+  desc: The first one
+  version: v1
+- id: two
+  desc: The second one
+  version: v2
+- id: three
+  desc: The third one
+  version: v3
+  

--- a/assets/cherry-pick/key-based-list.yml
+++ b/assets/cherry-pick/key-based-list.yml
@@ -1,0 +1,10 @@
+list:
+- key: one
+  desc: The first one
+  version: v1
+- key: two
+  desc: The second one
+  version: v2
+- key: three
+  desc: The third one
+  version: v3

--- a/assets/cherry-pick/name-based-list.yml
+++ b/assets/cherry-pick/name-based-list.yml
@@ -1,0 +1,19 @@
+list:
+- name: one
+  desc: The first one
+  version: v1
+- name: two
+  desc: The second one
+  version: v2
+- name: three
+  desc: The third one
+  version: v3
+- name: four
+  desc: The fourth one
+  version: v4
+- name: five
+  desc: The fifth one
+  version: v5
+- name: six
+  desc: The sixth one
+  version: v6

--- a/assets/cherry-pick/test-exact-names.yml
+++ b/assets/cherry-pick/test-exact-names.yml
@@ -1,0 +1,4 @@
+map:
+  subkey: this is the real subkey
+  other: value
+subkey: this is a fake subkey

--- a/cmd/spruce/main.go
+++ b/cmd/spruce/main.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	. "github.com/HeavyWombat/spruce"
+	. "github.com/geofffranks/spruce"
 	. "github.com/geofffranks/spruce/log"
 
 	"regexp"

--- a/cmd/spruce/main.go
+++ b/cmd/spruce/main.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	. "github.com/geofffranks/spruce"
+	. "github.com/HeavyWombat/spruce"
 	. "github.com/geofffranks/spruce/log"
 
 	"regexp"
@@ -60,7 +60,8 @@ func main() {
 		Concourse bool `goptions:"--concourse, description='Pre/Post-process YAML for Concourse CI (handles {{ }} quoting)'"`
 		Action    goptions.Verbs
 		Merge     struct {
-			Prune []string           `goptions:"--prune, description='Specify keys to prune from final output (may be specified more than once'"`
+			Prune []string           `goptions:"--prune, description='Specify keys to prune from final output (may be specified more than once)'"`
+			CherryPick []string      `goptions:"--cherry-pick, description='The opposite of prune, specify keys to cherry-pick from final output (may be specified more than once)'"`
 			Files goptions.Remainder `goptions:"description='Merges file2.yml through fileN.yml on top of file1.yml'"`
 		} `goptions:"merge"`
 		JSON struct {
@@ -101,7 +102,7 @@ func main() {
 			}
 
 			ev := &Evaluator{Tree: root}
-			err = ev.Run(options.Merge.Prune)
+			err = ev.Run(options.Merge.Prune, options.Merge.CherryPick)
 			if err != nil {
 				printfStdErr("%s\n", err.Error())
 				exit(2)

--- a/cmd/spruce/main_test.go
+++ b/cmd/spruce/main_test.go
@@ -814,7 +814,7 @@ releases:
 `)
 			})
 
-			Convey("Cherry pick a path and prune something at the same time", func() {
+			Convey("Cherry pick a path and prune something at the same time in a map", func() {
 				os.Args = []string{"spruce", "merge", "--cherry-pick", "properties", "--prune", "properties.vb.flags", "../../assets/cherry-pick/fileA.yml", "../../assets/cherry-pick/fileB.yml"}
 				stdout = ""
 				stderr = ""
@@ -838,6 +838,98 @@ releases:
 				So(stderr, ShouldEqual, "1 error(s) detected:\n"+
 					" - `$.properties` could not be found in the datastructure\n\n\n")
 				So(stdout, ShouldEqual, "")
+			})
+
+			Convey("Cherry picking should fail if picking a sub-level path while prune wipes the parent", func() {
+				os.Args = []string{"spruce", "merge", "--cherry-pick", "releases.vb", "--prune", "releases", "../../assets/cherry-pick/fileA.yml", "../../assets/cherry-pick/fileB.yml"}
+				stdout = ""
+				stderr = ""
+				main()
+				So(stderr, ShouldEqual, "1 error(s) detected:\n"+
+					" - `$.releases` could not be found in the datastructure\n\n\n")
+				So(stdout, ShouldEqual, "")
+			})
+
+			Convey("Cherry pick a list entry path of a list that uses 'key' as its identifier", func() {
+				os.Args = []string{"spruce", "merge", "--cherry-pick", "list.two", "../../assets/cherry-pick/key-based-list.yml"}
+				stdout = ""
+				stderr = ""
+				main()
+				So(stderr, ShouldEqual, "")
+				So(stdout, ShouldEqual, `list:
+- desc: The second one
+  key: two
+  version: v2
+
+`)
+			})
+
+			Convey("Cherry pick a list entry path of a list that uses 'id' as its identifier", func() {
+				os.Args = []string{"spruce", "merge", "--cherry-pick", "list.two", "../../assets/cherry-pick/id-based-list.yml"}
+				stdout = ""
+				stderr = ""
+				main()
+				So(stderr, ShouldEqual, "")
+				So(stdout, ShouldEqual, `list:
+- desc: The second one
+  id: two
+  version: v2
+
+`)
+			})
+
+			Convey("Cherry pick one list entry path that references the index", func() {
+				os.Args = []string{"spruce", "merge", "--cherry-pick", "list.1", "../../assets/cherry-pick/name-based-list.yml"}
+				stdout = ""
+				stderr = ""
+				main()
+				So(stderr, ShouldEqual, "")
+				So(stdout, ShouldEqual, `list:
+- desc: The second one
+  name: two
+  version: v2
+
+`)
+			})
+
+			Convey("Cherry pick two list entry paths that reference indexes", func() {
+				os.Args = []string{"spruce", "merge", "--cherry-pick", "list.1", "--cherry-pick", "list.4", "../../assets/cherry-pick/name-based-list.yml"}
+				stdout = ""
+				stderr = ""
+				main()
+				So(stderr, ShouldEqual, "")
+				So(stdout, ShouldEqual, `list:
+- desc: The fifth one
+  name: five
+  version: v5
+- desc: The second one
+  name: two
+  version: v2
+
+`)
+			})
+
+			Convey("Cherry pick one list entry path that references an invalid index", func() {
+				os.Args = []string{"spruce", "merge", "--cherry-pick", "list.10", "../../assets/cherry-pick/name-based-list.yml"}
+				stdout = ""
+				stderr = ""
+				main()
+				So(stderr, ShouldEqual, "1 error(s) detected:\n"+
+					" - `$.list.10` could not be found in the datastructure\n\n\n")
+				So(stdout, ShouldEqual, "")
+			})
+
+			Convey("Cherry pick should only pick the exact name based on the path", func() {
+				os.Args = []string{"spruce", "merge", "--cherry-pick", "map", "--prune", "subkey", "../../assets/cherry-pick/test-exact-names.yml"}
+				stdout = ""
+				stderr = ""
+				main()
+				So(stderr, ShouldEqual, "")
+				So(stdout, ShouldEqual, `map:
+  other: value
+  subkey: this is the real subkey
+
+`)
 			})
 		})
 	})

--- a/cmd/spruce/main_test.go
+++ b/cmd/spruce/main_test.go
@@ -740,6 +740,106 @@ z:
 `)
 			})
 		})
+
+		Convey("Cherry picking test cases", func() {
+			Convey("Cherry pick just one root level path", func() {
+				os.Args = []string{"spruce", "merge", "--cherry-pick", "properties", "../../assets/cherry-pick/fileA.yml", "../../assets/cherry-pick/fileB.yml"}
+				stdout = ""
+				stderr = ""
+				main()
+				So(stderr, ShouldEqual, "")
+				So(stdout, ShouldEqual, `properties:
+  hahn:
+    flags: open
+    id: b503e54a-c872-4643-a09c-5480c5940d0c
+  vb:
+    flags: auth,block,read-only
+    id: 74a03820-3f81-45ca-afd5-d7d57b947ff1
+
+`)
+			})
+
+			Convey("Cherry pick a path that is a list entry", func() {
+				os.Args = []string{"spruce", "merge", "--cherry-pick", "releases.vb", "../../assets/cherry-pick/fileA.yml", "../../assets/cherry-pick/fileB.yml"}
+				stdout = ""
+				stderr = ""
+				main()
+				So(stderr, ShouldEqual, "")
+				So(stdout, ShouldEqual, `releases:
+- name: vb
+
+`)
+			})
+
+			Convey("Cherry pick a path that is deep down the structure", func() {
+				os.Args = []string{"spruce", "merge", "--cherry-pick", "meta.some.deep.structure.maplist", "../../assets/cherry-pick/fileA.yml", "../../assets/cherry-pick/fileB.yml"}
+				stdout = ""
+				stderr = ""
+				main()
+				So(stderr, ShouldEqual, "")
+				So(stdout, ShouldEqual, `meta:
+  some:
+    deep:
+      structure:
+        maplist:
+          keyA: valueA
+          keyB: valueB
+
+`)
+			})
+
+			Convey("Cherry pick a series of different paths at the same time", func() {
+				os.Args = []string{"spruce", "merge", "--cherry-pick", "properties", "--cherry-pick", "releases.vb", "--cherry-pick", "meta.some.deep.structure.maplist", "../../assets/cherry-pick/fileA.yml", "../../assets/cherry-pick/fileB.yml"}
+				stdout = ""
+				stderr = ""
+				main()
+				So(stderr, ShouldEqual, "")
+				So(stdout, ShouldEqual, `meta:
+  some:
+    deep:
+      structure:
+        maplist:
+          keyA: valueA
+          keyB: valueB
+properties:
+  hahn:
+    flags: open
+    id: b503e54a-c872-4643-a09c-5480c5940d0c
+  vb:
+    flags: auth,block,read-only
+    id: 74a03820-3f81-45ca-afd5-d7d57b947ff1
+releases:
+- name: vb
+
+`)
+			})
+
+			Convey("Cherry pick a path and prune something at the same time", func() {
+				os.Args = []string{"spruce", "merge", "--cherry-pick", "properties", "--prune", "properties.vb.flags", "../../assets/cherry-pick/fileA.yml", "../../assets/cherry-pick/fileB.yml"}
+				stdout = ""
+				stderr = ""
+				main()
+				So(stderr, ShouldEqual, "")
+				So(stdout, ShouldEqual, `properties:
+  hahn:
+    flags: open
+    id: b503e54a-c872-4643-a09c-5480c5940d0c
+  vb:
+    id: 74a03820-3f81-45ca-afd5-d7d57b947ff1
+
+`)
+			})
+
+			Convey("Cherry picking should fail if you cherry-pick a prune path", func() {
+				os.Args = []string{"spruce", "merge", "--cherry-pick", "properties", "--prune", "properties", "../../assets/cherry-pick/fileA.yml", "../../assets/cherry-pick/fileB.yml"}
+				stdout = ""
+				stderr = ""
+				main()
+				So(stderr, ShouldEqual, "1 error(s) detected:\n"+
+					" - `$.properties` could not be found in the datastructure\n\n\n")
+				So(stdout, ShouldEqual, "")
+			})
+		})
 	})
 }
 

--- a/evaluator.go
+++ b/evaluator.go
@@ -257,7 +257,7 @@ func (ev *Evaluator) Prune(paths []string) error {
 func (ev *Evaluator) CherryPick(paths []string) error {
 	DEBUG("cherry-picking %d paths from the final YAML structure", len(paths))
 
-  if len(paths) > 0 {
+	if len(paths) > 0 {
 		// This will serve as the replacement tree ...
 		replacement := make(map[interface{}]interface{})
 
@@ -293,9 +293,19 @@ func (ev *Evaluator) CherryPick(paths []string) error {
 					// Empty parent string means we reached the root, setting the pointer nil to stop processing ...
 					pointer = nil
 
-					// ... and adding the cherry to the replacement map
-					DEBUG("Adding '%s' to the replacement tree", path)
-					replacement[cherryName] = cherryValue
+					// ... create the final cherry wrapped in its container ...
+					tmp := make(map[interface{}]interface{})
+					tmp[cherryName] = cherryValue
+
+					// ... and add it to the replacement map
+					DEBUG("Merging '%s' into the replacement tree", path)
+					merger := &Merger{AppendByDefault: true}
+					merged := merger.mergeObj(tmp, replacement, path)
+					if err := merger.Error(); err != nil {
+						return err
+					}
+
+					replacement = merged.(map[interface{}]interface{})
 
 				} else {
 					// Reassign the pointer to the parent and restructre the current cherry value to address the parent structure and name


### PR DESCRIPTION
Hey, we had a brief discussion about that some days ago. I looked into it and this would be my idea of the cherry-pick feature. You specify the path you want to have and everything else would be pruned. Pull request includes README update, test cases and the actual implementation.

Implementation/design ideas were: The cherry-pick phase comes after the prune phase. Prune and cherry-pick will work in combination as long as you do not specify non-sense combinations like `--prune properties --cherry-pick properties`. Of course, as discussed, it is only a command line flag since it makes no real sense as an operator.

I am not totality sure about the name. The original idea was something like `--keep`. However, since this feature is all about cherry-picking what you want, I though cherry-pick is a good enough name and also used in Git as a command line argument.

@jhunt @geofffranks  What do you think?