### PR TITLE
New feature: (( delete ... )) can use regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,18 @@ Arrays can be modified in multiple ways: prepending data, appending data, insert
   ```yml
   - (( delete <key> "<name>" ))
   ```
+  Additionally, this operation supports **regex**. For example you could use something like the following to remove `dea_z1`, `dea_z2`,..., `dea_zN`:
+
+  ```yml
+  jobs:
+  - (( delete "dea.*" ))
+  ```
+
   <br> The array modification operations `(( append ))`, `(( prepend ))`, `(( delete ... ))`, and `(( insert ... ))` can be
   used multiple times in one list. Entries that follow `(( append ))`, `(( prepend ))`, and `(( insert ... ))` belong to the
   same operation. This however does not apply to `(( delete ... ))`, which always stands alone.
+
+
 
 - To replace the first array with the second,
   ensure that the first element in the new array is <br>

--- a/README.md
+++ b/README.md
@@ -117,6 +117,28 @@ Arrays can be modified in multiple ways: prepending data, appending data, insert
   jobs:
   - (( delete "dea.*" ))
   ```
+  Same works also in case of `(( insert after/before ))`. In this case, it will insert the item after the first occurrence. Ex:
+  ```yml
+  jobs:
+  - (( insert after "dea.*" ))
+  - name: dea_z2
+  ```
+  ```yml
+  jobs:
+  - name: dea
+  - name: brain
+  - name: dea09
+  ```
+  Result:
+  ```yml
+  jobs:
+  - name: dea_z1
+  - name: dea_z2
+  - name: brain
+  - name: dea_z3
+  ```
+
+
 
   <br> The array modification operations `(( append ))`, `(( prepend ))`, `(( delete ... ))`, and `(( insert ... ))` can be
   used multiple times in one list. Entries that follow `(( append ))`, `(( prepend ))`, and `(( insert ... ))` belong to the

--- a/cmd/spruce/main_test.go
+++ b/cmd/spruce/main_test.go
@@ -982,5 +982,13 @@ func TestExamples(t *testing.T) {
 				"../../examples/inserting/result.yml",
 			)
 		})
+		Convey("Delete", func() {
+			example(
+				"../../examples/delete/main.yml",
+				"../../examples/delete/addon.yml",
+
+				"../../examples/delete/result.yml",
+			)
+		})
 	})
 }

--- a/examples/delete/addon.yml
+++ b/examples/delete/addon.yml
@@ -2,3 +2,4 @@
 jobs:
 - (( delete name "ccdb" ))
 - (( delete "dea" ))
+- (( delete  "api.*" ))

--- a/examples/delete/main.yml
+++ b/examples/delete/main.yml
@@ -6,9 +6,9 @@ jobs:
   instances: 2
 - name: ccdb
   instances: 3
-- name: uaadb
-  instances: 4
 - name: dea
   instances: 5
 - name: api
+  instances: 6
+- name: api_v2
   instances: 6

--- a/examples/delete/result.yml
+++ b/examples/delete/result.yml
@@ -3,7 +3,3 @@ jobs:
   name: consul
 - instances: 2
   name: nats
-- instances: 4
-  name: uaadb
-- instances: 6
-  name: api

--- a/examples/inserting/addon.yml
+++ b/examples/inserting/addon.yml
@@ -1,8 +1,8 @@
 ---
 jobs:
-- (( insert after "dea" ))
+- (( insert after "dea.*" ))
 - name: dea_v2
   instances: 2
-- (( insert after "dea.+" ))
+- (( insert after "dea_.+" ))
 - name: dea_v3
   instances: 2

--- a/examples/inserting/addon.yml
+++ b/examples/inserting/addon.yml
@@ -3,3 +3,6 @@ jobs:
 - (( insert after "dea" ))
 - name: dea_v2
   instances: 2
+- (( insert after "dea.+" ))
+- name: dea_v3
+  instances: 2

--- a/examples/inserting/result.yml
+++ b/examples/inserting/result.yml
@@ -13,4 +13,6 @@ jobs:
 - instances: 2
   name: dea_v2
 - instances: 2
+  name: dea_v3
+- instances: 2
   name: api

--- a/merge.go
+++ b/merge.go
@@ -246,11 +246,16 @@ func (m *Merger) mergeArray(orig []interface{}, n []interface{}, node string) []
 					return nil
 				}
 				if _, err := regexp.Compile(name); err != nil {
-					m.Errors.Append(ansi.Errorf("@m{%s}: @R{unable to compile regex} @c{%s} @R{is out of bounds}", node, name))
+					m.Errors.Append(ansi.Errorf("@m{%s}: @R{unable to compile regex} @c{%s}", node, name))
 					return nil
 				}
 
 				idx = getIndexOfEntry(result, key, name)
+
+				if idx < 0 {
+					m.Errors.Append(ansi.Errorf("@m{%s}: @R{unable to modify the list, because specified index} @c{%d} @R{is out of bounds}", node, idx))
+					return nil
+				}
 
 				for idx >= 0 {
 					DEBUG("%s: deleting element at array index %d", node, idx)

--- a/merge.go
+++ b/merge.go
@@ -253,7 +253,7 @@ func (m *Merger) mergeArray(orig []interface{}, n []interface{}, node string) []
 				idx = getIndexOfEntry(result, key, name)
 
 				if idx < 0 {
-					m.Errors.Append(ansi.Errorf("@m{%s}: @R{unable to modify the list, because specified index} @c{%d} @R{is out of bounds}", node, idx))
+					m.Errors.Append(ansi.Errorf("@m{%s}: @R{unable to find specified modification point with} @c{'%s: %s'}", node, key, name))
 					return nil
 				}
 

--- a/merge_test.go
+++ b/merge_test.go
@@ -1722,7 +1722,7 @@ func TestMergeArray(t *testing.T) {
 				So(err, ShouldBeNil)
 			})
 
-			Convey("Delete  '<default>: .*first.*' with simple regex", func() {
+			Convey("Delete  '<default>: first.+' with simple regex", func() {
 				orig := []interface{}{
 					map[interface{}]interface{}{"name": "first", "release": "v1"},
 					map[interface{}]interface{}{"name": "first_z2", "release": "v1"},
@@ -1735,6 +1735,29 @@ func TestMergeArray(t *testing.T) {
 
 				expect := []interface{}{
 					map[interface{}]interface{}{"name": "first", "release": "v1"},
+					map[interface{}]interface{}{"name": "second", "release": "v1"},
+				}
+
+				m := &Merger{}
+				a := m.mergeArray(orig, array, "node-path")
+				err := m.Error()
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Delete when key contains special characters", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{"name": "fi.st", "release": "v1"},
+					map[interface{}]interface{}{"name": "second", "release": "v1"},
+					map[interface{}]interface{}{"name": "th*rd+", "release": "v1"},
+				}
+
+				array := []interface{}{
+					"(( delete \"fi\\.st\" ))",
+					"(( delete \"th\\*rd\\+\" ))",
+				}
+
+				expect := []interface{}{
 					map[interface{}]interface{}{"name": "second", "release": "v1"},
 				}
 

--- a/merge_test.go
+++ b/merge_test.go
@@ -1132,6 +1132,56 @@ func TestMergeArray(t *testing.T) {
 				So(err, ShouldBeNil)
 			})
 
+			Convey("After '<default>: first.+' put the new entry", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{"name": "first_z1", "release": "v1"},
+					map[interface{}]interface{}{"name": "second", "release": "v1"},
+				}
+
+				array := []interface{}{
+					"(( insert after \"first.+\" ))",
+					map[interface{}]interface{}{"name": "new-kid-on-the-block", "release": "vNext"},
+				}
+
+				expect := []interface{}{
+					map[interface{}]interface{}{"name": "first_z1", "release": "v1"},
+					map[interface{}]interface{}{"name": "new-kid-on-the-block", "release": "vNext"},
+					map[interface{}]interface{}{"name": "second", "release": "v1"},
+				}
+
+				m := &Merger{}
+				a := m.mergeArray(orig, array, "node-path")
+				err := m.Error()
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
+			})
+
+			Convey("After '<default>: first.+' put the new entry after the first occurrence", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{"name": "first_z1", "release": "v1"},
+					map[interface{}]interface{}{"name": "second", "release": "v1"},
+					map[interface{}]interface{}{"name": "first_z2", "release": "v1"},
+				}
+
+				array := []interface{}{
+					"(( insert after \"first.+\" ))",
+					map[interface{}]interface{}{"name": "new-kid-on-the-block", "release": "vNext"},
+				}
+
+				expect := []interface{}{
+					map[interface{}]interface{}{"name": "first_z1", "release": "v1"},
+					map[interface{}]interface{}{"name": "new-kid-on-the-block", "release": "vNext"},
+					map[interface{}]interface{}{"name": "second", "release": "v1"},
+					map[interface{}]interface{}{"name": "first_z2", "release": "v1"},
+				}
+
+				m := &Merger{}
+				a := m.mergeArray(orig, array, "node-path")
+				err := m.Error()
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
+			})
+
 			Convey("Before '<default>: first' put the new entry", func() {
 				orig := []interface{}{
 					map[interface{}]interface{}{"name": "first", "release": "v1"},
@@ -1171,6 +1221,30 @@ func TestMergeArray(t *testing.T) {
 					map[interface{}]interface{}{"id": "first", "release": "v1"},
 					map[interface{}]interface{}{"id": "second", "release": "v1"},
 					map[interface{}]interface{}{"id": "new-kid-on-the-block", "release": "vNext"},
+				}
+
+				m := &Merger{}
+				a := m.mergeArray(orig, array, "node-path")
+				err := m.Error()
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Before 'id: second.+' put the new entry", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{"id": "first", "release": "v1"},
+					map[interface{}]interface{}{"id": "second_z2", "release": "v1"},
+				}
+
+				array := []interface{}{
+					"(( insert before id \"second.+\" ))",
+					map[interface{}]interface{}{"id": "new-kid-on-the-block", "release": "vNext"},
+				}
+
+				expect := []interface{}{
+					map[interface{}]interface{}{"id": "first", "release": "v1"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block", "release": "vNext"},
+					map[interface{}]interface{}{"id": "second_z2", "release": "v1"},
 				}
 
 				m := &Merger{}

--- a/merge_test.go
+++ b/merge_test.go
@@ -1282,19 +1282,17 @@ func TestMergeArray(t *testing.T) {
 				orig := []interface{}{
 					map[interface{}]interface{}{"name": "fi.st", "release": "v1"},
 					map[interface{}]interface{}{"name": "second", "release": "v1"},
-					map[interface{}]interface{}{"name": "th*rd+", "release": "v1"},
 				}
 
 				array := []interface{}{
 					"(( insert after \"fi\\.st\" ))",
-					map[interface{}]interface{}{"id": "new-kid-on-the-block", "release": "vNext"},
+					map[interface{}]interface{}{"name": "new-kid-on-the-block", "release": "vNext"},
 				}
 
 				expect := []interface{}{
 					map[interface{}]interface{}{"name": "fi.st", "release": "v1"},
-					map[interface{}]interface{}{"id": "new-kid-on-the-block", "release": "vNext"},
+					map[interface{}]interface{}{"name": "new-kid-on-the-block", "release": "vNext"},
 					map[interface{}]interface{}{"name": "second", "release": "v1"},
-					map[interface{}]interface{}{"name": "th*rd+", "release": "v1"},
 				}
 
 				m := &Merger{}

--- a/merge_test.go
+++ b/merge_test.go
@@ -1886,7 +1886,7 @@ func TestMergeArray(t *testing.T) {
 				So(err, ShouldBeNil)
 			})
 
-			Convey("don't throw an error when delete point cannot be found", func() {
+			Convey("throw an error when delete point cannot be found", func() {
 				orig := []interface{}{
 					map[interface{}]interface{}{"name": "first", "release": "v1"},
 					map[interface{}]interface{}{"name": "second", "release": "v1"},
@@ -1899,8 +1899,9 @@ func TestMergeArray(t *testing.T) {
 				m := &Merger{}
 				a := m.mergeArray(orig, array, "node-path")
 				err := m.Error()
-				So(a, ShouldResemble, orig)
-				So(err, ShouldBeNil)
+				So(a, ShouldBeNil)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "unable to find specified modification point with 'name: not-existing'")
 			})
 
 			Convey("throw an error when delete cannot be compile a regex", func() {

--- a/merge_test.go
+++ b/merge_test.go
@@ -1278,6 +1278,32 @@ func TestMergeArray(t *testing.T) {
 				So(err, ShouldBeNil)
 			})
 
+			Convey("Insert after when key contains special characters", func() {
+				orig := []interface{}{
+					map[interface{}]interface{}{"name": "fi.st", "release": "v1"},
+					map[interface{}]interface{}{"name": "second", "release": "v1"},
+					map[interface{}]interface{}{"name": "th*rd+", "release": "v1"},
+				}
+
+				array := []interface{}{
+					"(( insert after \"fi\\.st\" ))",
+					map[interface{}]interface{}{"id": "new-kid-on-the-block", "release": "vNext"},
+				}
+
+				expect := []interface{}{
+					map[interface{}]interface{}{"name": "fi.st", "release": "v1"},
+					map[interface{}]interface{}{"id": "new-kid-on-the-block", "release": "vNext"},
+					map[interface{}]interface{}{"name": "second", "release": "v1"},
+					map[interface{}]interface{}{"name": "th*rd+", "release": "v1"},
+				}
+
+				m := &Merger{}
+				a := m.mergeArray(orig, array, "node-path")
+				err := m.Error()
+				So(a, ShouldResemble, expect)
+				So(err, ShouldBeNil)
+			})
+
 			Convey("Insert multiple new entries before second and after first", func() {
 				orig := []interface{}{
 					map[interface{}]interface{}{"id": "first", "release": "v1"},


### PR DESCRIPTION
Hi guys, 

During my time working on Concourse, I have had the problem that I needed to remove things like: 

```
jobs: 
- name: cell_z2
- name: brain_z2
```

I have added some logic to be able to use regex on (( delete ...)) commands. For example: 

```
jobs: 
- (( delete ".*_z2" ))
```

That will remove all jobs with the ending `_z2`. 
