### PR TITLE
Handle Escape Sequences in strings

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,5 @@
+## Improvements
+
+- Operator argument string literals can now contain `\n`, `\r` and
+  `\t`, with the expected results.  Notably, this allows multiline
+  string pasting, which was impossible in previous versions. (#175)

--- a/evaluator_test.go
+++ b/evaluator_test.go
@@ -1524,6 +1524,99 @@ output:
 - hello world
 z_one: hello
 z_two: world
+
+
+################################################   basic escape sequence handling
+---
+test: ""
+cr:   (( concat test "a\rb" ))
+nl:   (( concat test "a\nb" ))
+tab:  (( concat test "a\tb" ))
+back: (( concat test "a\\b" ))
+dq:   (( concat test "a\"b" ))
+sq:   (( concat test "a\'b" ))
+
+---
+dataflow:
+- back: (( concat test "a\\b" ))
+- cr:   (( concat test "a\rb" ))
+- dq:   (( concat test "a\"b" ))
+- nl:   (( concat test "a\nb" ))
+- sq:   (( concat test "a\'b" ))
+- tab:  (( concat test "a\tb" ))
+
+---
+test: ""
+cr:   "a\rb"
+nl:   "a\nb"
+tab:  "a\tb"
+back: a\b
+dq:   'a"b'
+sq:   "a'b"
+
+
+#############################################   repeated escape sequence handling
+---
+compound: (( concat "Line1\nLine2\nLine3" "\n" "Line4\ttabbed\n" ))
+
+---
+dataflow:
+- compound: (( concat "Line1\nLine2\nLine3" "\n" "Line4\ttabbed\n" ))
+
+---
+compound: |
+  Line1
+  Line2
+  Line3
+  Line4	tabbed
+
+
+########################################   concat certs with newlines (escape seq)
+---
+cert: |-
+  -- BEGIN CERT --
+  unei3Eet2mahbou8
+  weiXi7choo7ufei8
+  --- END CERT ---
+
+key: |-
+  -- BEGIN KEY ---
+  chaev0Gai3Baedul
+  noithaifu0ree0Ka
+  shoowuBaoti4chee
+  -- END KEY -----
+
+combined: (( concat cert "\n" key "\n" ))
+
+---
+dataflow:
+- combined: (( concat cert "\n" key "\n" ))
+
+---
+cert: |-
+  -- BEGIN CERT --
+  unei3Eet2mahbou8
+  weiXi7choo7ufei8
+  --- END CERT ---
+
+key: |-
+  -- BEGIN KEY ---
+  chaev0Gai3Baedul
+  noithaifu0ree0Ka
+  shoowuBaoti4chee
+  -- END KEY -----
+
+combined: |
+  -- BEGIN CERT --
+  unei3Eet2mahbou8
+  weiXi7choo7ufei8
+  --- END CERT ---
+  -- BEGIN KEY ---
+  chaev0Gai3Baedul
+  noithaifu0ree0Ka
+  shoowuBaoti4chee
+  -- END KEY -----
+
 `)
 	})
 

--- a/operator.go
+++ b/operator.go
@@ -276,7 +276,16 @@ func ParseOpcall(phase OperatorPhase, src string) (*Opcall, error) {
 
 		for _, c := range src {
 			if escaped {
-				buf += string(c)
+				switch c {
+				case 'n':
+					buf += "\n"
+				case 'r':
+					buf += "\r"
+				case 't':
+					buf += "\t"
+				default:
+					buf += string(c)
+				}
 				escaped = false
 				continue
 			}
@@ -319,7 +328,7 @@ func ParseOpcall(phase OperatorPhase, src string) (*Opcall, error) {
 	}
 
 	argify := func(src string) (args []*Expr, err error) {
-		qstring := regexp.MustCompile(`^"(.*)"$`)
+		qstring := regexp.MustCompile(`(?s)^"(.*)"$`)
 		integer := regexp.MustCompile(`^[+-]?\d+(\.\d+)?$`)
 		float := regexp.MustCompile(`^[+-]?\d*\.\d+$`)
 		envvar := regexp.MustCompile(`^\$[A-Z_][A-Z0-9_]*$`)


### PR DESCRIPTION
Operator argument literals ("...") now properly treat the standard
backslash escape sequences `\n` (newline), `\r` (carriage return) and
`\t` (horizontal tab).  Other escape sequences resolve to themselves, as
before.

Fixes #175