### PR TITLE
Honor TLS/SSL verification settings from `safe -k`

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,9 @@
+## Improvements
+
+- `spruce` now supports the `skip_verify` addition to the
+  `~/.svtoken` file ([safe 0.0.28+][safe]).  That means that if
+  you target a vault with safe, and you tell safe to ignore
+  certificate errors, spruce will honor those settings.
+
+
+[safe]: https://github.com/starkandwayne/safe/releases/tag/v0.0.28


### PR DESCRIPTION
re: https://github.com/starkandwayne/safe/releases/tag/v0.0.28

As of safe release 0.0.28, targeting a Vault with `-k` will persist for
future operations.  This is done by way of the `~/.svtoken` file.

This commit introduces support for that new addition, and causes Spruce
to behave according to the `safe` operator's wishes.