### PR TITLE
Fix int64 calc issue

### DIFF
--- a/assets/calc/dependencies.yml
+++ b/assets/calc/dependencies.yml
@@ -1,6 +1,7 @@
 ---
 meta:
   target_mem: 144
+  extras: (( grab meta.custom-extras || 0 ))
 
 jobs:
 - name: big_ones
@@ -8,3 +9,6 @@ jobs:
 
 - name: small_ones
   instances: (( calc "floor((meta.target_mem - jobs.big_ones.instances * 32) / 16)" ))
+
+- name: extra_ones
+  instances: (( calc "2 + meta.extras" ))

--- a/cmd/spruce/main_test.go
+++ b/cmd/spruce/main_test.go
@@ -774,6 +774,8 @@ z:
   name: big_ones
 - instances: 1
   name: small_ones
+- instances: 2
+  name: extra_ones
 
 `)
 			})

--- a/op_calc.go
+++ b/op_calc.go
@@ -143,10 +143,10 @@ func replaceReferences(ev *Evaluator, input string) (string, error) {
 		DEBUG("    path/value: %s=%v", path, value)
 
 		switch value.(type) {
-		case int:
+		case int, uint8, uint16, uint32, uint64, int8, int16, int32, int64:
 			input = strings.Replace(input, path, fmt.Sprintf("%d", value), -1)
 
-		case float64:
+		case float32, float64:
 			input = strings.Replace(input, path, fmt.Sprintf("%f", value), -1)
 
 		case nil:


### PR DESCRIPTION
I extended the dependencies test case with another dependency that itself uses the `||` operator to fallback to an `int64` in this case. In this scenario, the `path meta.foobar is of type int64, which cannot be used in calculations` error message appears. This is why I consulted the [numeric types](https://golang.org/ref/spec#Numeric_types) section of the Golang documentation to add all supported integer and floating-point numbers to the `switch` statement. This part of the code deals with resolving the dependencies into their string representation to be used by the math expression library.

This should fix #191.
