### PR TITLE
Add support for reading YAML from stdin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ go:
 sudo: false
 
 script:
-- make test
+- make

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: vet test build
+all: vet test build clitests
 
 vet:
 	go list ./... | grep -v vendor | xargs go vet
@@ -8,6 +8,9 @@ test:
 
 colortest: build
 	./assets/color_tester
+
+clitests: build
+	./assets/cli_tests
 
 build:
 	go build ./cmd/spruce

--- a/assets/cli_tests
+++ b/assets/cli_tests
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+cleanup() {
+	rm -rf ${TMPDIR}
+}
+
+TMPDIR=$(mktemp -d)
+trap cleanup QUIT INT EXIT
+
+cat <<EOF > ${TMPDIR}/first.yml
+---
+first: beginning
+EOF
+
+cat <<EOF > ${TMPDIR}/last.yml
+---
+last: ending
+EOF
+
+cp spruce ${TMPDIR}
+pushd ${TMPDIR}
+
+result=$(echo "first: stdin" | ./spruce merge)
+[[ ${result} == "first: stdin" ]]
+
+result=$(echo "first: stdin" | ./spruce merge -)
+[[ ${result} == "first: stdin" ]]
+
+result=$(echo "first: stdin" | ./spruce merge first.yml - last.yml)
+[[ ${result} == "first: stdin\nlast: ending" ]]
+
+result=$(echo "last: stdin" | ./spruce merge first.yml - last.yml)
+[[ ${result} == "first: beginning\nlast: ending" ]]
+
+popd

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,16 @@
+# Improvements
+
+- `spruce merge` can now read input from STDIN, if you are piping
+  another program's YAML output to it. You can make use of it anywhere
+  in the merge order using the `-` filename. Additionally, if no
+  files are mentioned, and data is being piped in, spruce will
+  happily read the data from STDIN, process operators, and provide
+  the output.
+
+  Examples:
+
+      echo my: value | spruce merge
+      echo my: value | spruce merge -
+      echo my: value | spruce merge first.yml - last.yml
+      echo my: value | spruce merge first.yml last.yml -
+

--- a/ci/scripts/test
+++ b/ci/scripts/test
@@ -8,5 +8,4 @@ cd ${GOPATH}/src/${MODULE}
 
 godep restore
 
-go list ./... | grep -v vendor | xargs go vet
-go list ./... | grep -v vendor | xargs go test
+make # runs vet, test, and build

--- a/cmd/spruce/main_test.go
+++ b/cmd/spruce/main_test.go
@@ -154,13 +154,13 @@ func TestMain(t *testing.T) {
 			So(stderr, ShouldEqual, "usage was called")
 			So(rc, ShouldEqual, 1)
 		})
-		Convey("Should output usage if no args to merge", func() {
+		Convey("Should error if no args to merge and no files listed", func() {
 			os.Args = []string{"spruce", "merge"}
 			stdout = ""
 			stderr = ""
 			main()
-			So(stderr, ShouldEqual, "usage was called")
-			So(rc, ShouldEqual, 1)
+			So(stderr, ShouldEqual, "Error reading STDIN: no data found. Did you forget to pipe data to STDIN, or specify yaml files to merge?\n")
+			So(rc, ShouldEqual, 2)
 		})
 		Convey("Should output version", func() {
 			Convey("When '-v' is specified", func() {


### PR DESCRIPTION
`spruce merge` now has the ability to read
YAML data from piped STDIN. Reading from
the terminal's STDIN is not supported for
better user experience when files are not
specified. Supported ways of using this:

    echo my: yaml | spruce merge   # merges STDIN with nothing else
    echo my: yaml | spruce merge - # Explicitly merges STDIN with nothing else
    echo my: yaml | spruce merge first.yml - # Merges STDIN on top of first.yml

And so on.