### PR TITLE
Update tree with fixed error handling for '*' Globs

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -59,11 +59,11 @@
 		},
 		{
 			"ImportPath": "github.com/starkandwayne/goutils/ansi",
-			"Rev": "1af0d9806cdff1eaa84c422f7bea313f3c4d073f"
+			"Rev": "c408a779c021921dd1a7a7779edc80dec0d91a4e"
 		},
 		{
 			"ImportPath": "github.com/starkandwayne/goutils/tree",
-			"Rev": "1af0d9806cdff1eaa84c422f7bea313f3c4d073f"
+			"Rev": "c408a779c021921dd1a7a7779edc80dec0d91a4e"
 		},
 		{
 			"ImportPath": "github.com/voxelbrain/goptions",

--- a/assets/static_ips/vips-plus-grab.yml
+++ b/assets/static_ips/vips-plus-grab.yml
@@ -1,0 +1,17 @@
+meta:
+  ips:
+    - 1.2.3.4
+
+networks:
+- name: stuff
+  subnets:
+  - static: (( grab meta.ips ))
+- name: stuff2
+  type: vip
+
+jobs:
+- name: bosh
+  instances: 1
+  networks:
+  - name: stuff
+    static_ips: (( static_ips(0) ))

--- a/cmd/spruce/main_test.go
+++ b/cmd/spruce/main_test.go
@@ -678,6 +678,34 @@ networks:
 `)
 		})
 
+		Convey("Issue #194 Globs with missing sub-items track data flow deps properly", func() {
+			os.Args = []string{"spruce", "merge", "../../assets/static_ips/vips-plus-grab.yml"}
+			stdout = ""
+			stderr = ""
+
+			main()
+			So(stderr, ShouldEqual, "")
+			So(stdout, ShouldEqual, `jobs:
+- instances: 1
+  name: bosh
+  networks:
+  - name: stuff
+    static_ips:
+    - 1.2.3.4
+meta:
+  ips:
+  - 1.2.3.4
+networks:
+- name: stuff
+  subnets:
+  - static:
+    - 1.2.3.4
+- name: stuff2
+  type: vip
+
+`)
+		})
+
 		Convey("Empty operator works", func() {
 
 			var baseFile, mergeFile string

--- a/op_static_ips.go
+++ b/op_static_ips.go
@@ -51,6 +51,7 @@ func (StaticIPOperator) Dependencies(ev *Evaluator, _ []*Expr, _ []*tree.Cursor)
 
 	// need all the network name decls
 	track("networks.*.name")
+	track("networks.*.subnets")
 
 	// need all the static range decls
 	track("networks.*.subnets.*.static")

--- a/vendor/github.com/starkandwayne/goutils/ansi/printf.go
+++ b/vendor/github.com/starkandwayne/goutils/ansi/printf.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"regexp"
+	"unicode"
 
 	"github.com/mattn/go-isatty"
 )
@@ -38,7 +39,7 @@ var (
 		"W": "01;37", // white (BOLD)
 	}
 
-	re = regexp.MustCompile(`@[kKrRgGyYbBmMpPcCwW*]{.*?}`)
+	re = regexp.MustCompile(`(?s)@[kKrRgGyYbBmMpPcCwW*]{.*?}`)
 )
 
 var colorable = isatty.IsTerminal(os.Stdout.Fd())
@@ -54,9 +55,15 @@ func colorize(s string) string {
 		}
 		if m[1:2] == "*" {
 			rainbow := "RYGCBM"
+			skipCount := 0
 			s := ""
 			for i, c := range m[3 : len(m)-1] {
-				j := i % len(rainbow)
+				if unicode.IsSpace(c) { //No color wasted on whitespace
+					skipCount++
+					s += string(c)
+					continue
+				}
+				j := (i - skipCount) % len(rainbow)
 				s += "\033[" + colors[rainbow[j:j+1]] + "m" + string(c) + "\033[00m"
 			}
 			return s

--- a/vendor/github.com/starkandwayne/goutils/tree/cursor.go
+++ b/vendor/github.com/starkandwayne/goutils/tree/cursor.go
@@ -249,7 +249,9 @@ func (c *Cursor) Glob(tree interface{}) ([]*Cursor, error) {
 				for i, v := range o.([]interface{}) {
 					sub, err := resolver(v, append(here, fmt.Sprintf("%d", i)), path, pos+1)
 					if err != nil {
-						return nil, err
+						if _, ok := err.(NotFoundError); !ok {
+							return nil, err
+						}
 					}
 					paths = append(paths, sub...)
 				}
@@ -258,7 +260,9 @@ func (c *Cursor) Glob(tree interface{}) ([]*Cursor, error) {
 				for k, v := range o.(map[string]interface{}) {
 					sub, err := resolver(v, append(here, k), path, pos+1)
 					if err != nil {
-						return nil, err
+						if _, ok := err.(NotFoundError); !ok {
+							return nil, err
+						}
 					}
 					paths = append(paths, sub...)
 				}
@@ -267,7 +271,9 @@ func (c *Cursor) Glob(tree interface{}) ([]*Cursor, error) {
 				for k, v := range o.(map[interface{}]interface{}) {
 					sub, err := resolver(v, append(here, fmt.Sprintf("%v", k)), path, pos+1)
 					if err != nil {
-						return nil, err
+						if _, ok := err.(NotFoundError); !ok {
+							return nil, err
+						}
 					}
 					paths = append(paths, sub...)
 				}


### PR DESCRIPTION
Fixes #194

Allows Globs with '*'s to ignore not-found items, so that
data flow analysis can properly track dependencies in situations
where there are networks with subnets, and networks without subnets
for the static_ips operator.