### PR TITLE
Fix --cherry-pick so that it lazy-evaluates

### DIFF
--- a/assets/cherry-pick/partial-eval.yml
+++ b/assets/cherry-pick/partial-eval.yml
@@ -1,0 +1,12 @@
+---
+meta:
+  type: thing
+params:
+  name: (( grab name ))
+  mode: default
+
+env: sandbox
+type: (( grab meta.type ))
+name: (( concat env "-" type ))
+
+skipped: (( grab should.throw.an.error.if.evaluated ))

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,3 +1,9 @@
+# Improvements
+
+- `spruce merge --cherry-pick` now no longer evaluates the entire
+  tree of operators before returning a subset.  Instead, operators
+  that are not involved in the final tree are ignored.
+
 # Bug Fixes
 
 - Resolved an issue with the `(( static_ips ))` operator not always resolving

--- a/cmd/spruce/main_test.go
+++ b/cmd/spruce/main_test.go
@@ -1082,6 +1082,19 @@ releases:
 
 `)
 			})
+
+			Convey("Cherry pick should only evaluate the dynamic operators that are relevant", func() {
+				os.Args = []string{"spruce", "merge", "--cherry-pick", "params", "../../assets/cherry-pick/partial-eval.yml"}
+				stdout = ""
+				stderr = ""
+				main()
+				So(stderr, ShouldEqual, "")
+				So(stdout, ShouldEqual, `params:
+  mode: default
+  name: sandbox-thing
+
+`)
+			})
 		})
 
 		Convey("non-specific node tags specific test cases", func() {


### PR DESCRIPTION
Now, the `--cherry-pick` option causes Spruce to only evaluate the parts
of the hierarchy that are actually being cherry-picked.