### PR TITLE
Key merge no longer panics if target keys' value is sequence or hash

### DIFF
--- a/assets/issue-172/explicitmerge1.yml
+++ b/assets/issue-172/explicitmerge1.yml
@@ -1,0 +1,4 @@
+---
+array-of-maps:
+- (( merge ))
+- name: { subkey1: yes, subkey2: no }

--- a/assets/issue-172/explicitmergeonkey1.yml
+++ b/assets/issue-172/explicitmergeonkey1.yml
@@ -1,0 +1,3 @@
+array-of-maps:
+- (( merge on mergekey ))
+- mergekey: { subkey1: yes, subkey2: no }

--- a/assets/issue-172/implicitmergemap.yml
+++ b/assets/issue-172/implicitmergemap.yml
@@ -1,0 +1,3 @@
+---
+array-of-maps:
+- name: { subkey1: yes, subkey2: no }

--- a/assets/issue-172/implicitmergeseq.yml
+++ b/assets/issue-172/implicitmergeseq.yml
@@ -1,0 +1,3 @@
+---
+array-of-maps:
+- name: [ subkey1, subkey2 ]

--- a/cmd/spruce/main.go
+++ b/cmd/spruce/main.go
@@ -29,7 +29,7 @@ var printfStdOut = func(format string, args ...interface{}) {
 }
 
 var printfStdErr = func(format string, args ...interface{}) {
-	fmt.Fprintf(os.Stderr, format, args...)
+	PrintfStdErr(format, args...)
 }
 
 var getopts = func(o interface{}) {

--- a/errors.go
+++ b/errors.go
@@ -2,9 +2,11 @@ package spruce
 
 import (
 	"fmt"
-	"github.com/starkandwayne/goutils/ansi"
 	"sort"
 	"strings"
+
+	"github.com/geofffranks/spruce/log"
+	"github.com/starkandwayne/goutils/ansi"
 )
 
 // MultiError ...
@@ -38,5 +40,63 @@ func (e *MultiError) Append(err error) {
 		e.Errors = append(e.Errors, mult.Errors...)
 	} else {
 		e.Errors = append(e.Errors, err)
+	}
+}
+
+//WarningError should produce a warning message to stderr if the context set for
+// the error fits the context the error was caught in.
+type WarningError struct {
+	warning string
+	context ErrorContext
+}
+
+//An ErrorContext is a flag or set of flags representing the contexts that
+// an error should have a special meaning in.
+type ErrorContext uint
+
+//Bitwise-or these together to represent several contexts
+const (
+	eContextAll          = 0
+	eContextDefaultMerge = 1 << iota
+)
+
+var dontPrintWarning bool
+
+//NewWarningError returns a new WarningError object that has the given warning
+// message and context(s) assigned. Assigning no context should mean that all
+// contexts are active. Ansi library enabled.
+func NewWarningError(context ErrorContext, warning string, args ...interface{}) (err WarningError) {
+	err.warning = ansi.Sprintf(warning, args...)
+	err.context = context
+	return
+}
+
+//SilenceWarnings when called with true will make it so that warnings will not
+// print when Warn is called. Calling it with false will make warnings visible
+// again. Warnings will print by default.
+func SilenceWarnings(should bool) {
+	dontPrintWarning = should
+}
+
+//Error will return the configured warning message as a string
+func (e WarningError) Error() string {
+	return e.warning
+}
+
+//HasContext returns true if the WarningError was configured with the given context (or all).
+// False otherwise.
+func (e WarningError) HasContext(context ErrorContext) bool {
+	return e.context == 0 || (context&e.context > 0)
+}
+
+//SetWarning sets the warning message for this WarningError. Ansi library rnabled
+func (e *WarningError) SetWarning(warning string) {
+	e.warning = warning
+}
+
+//Warn prints the configured warning to stderr.
+func (e WarningError) Warn() {
+	if !dontPrintWarning {
+		log.PrintfStdErr(ansi.Sprintf("@Y{warning:} %s\n", e.warning))
 	}
 }

--- a/evaluator_test.go
+++ b/evaluator_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestEvaluator(t *testing.T) {
+	SilenceWarnings(true)
 	YAML := func(s string) map[interface{}]interface{} {
 		y, err := simpleyaml.NewYaml([]byte(s))
 		So(err, ShouldBeNil)

--- a/log/log.go
+++ b/log/log.go
@@ -9,14 +9,16 @@ import (
 var DebugOn bool = false
 var TraceOn bool = false
 
-var printfStdErr func(string, ...interface{})
+//PrintfStdErr is a configurable hook to print to error output
+var PrintfStdErr func(string, ...interface{})
 
 func init() {
-	printfStdErr = func(format string, args ...interface{}) {
+	PrintfStdErr = func(format string, args ...interface{}) {
 		fmt.Fprintf(os.Stderr, format, args...)
 	}
 }
 
+// DEBUG - Prints out a debug message
 func DEBUG(format string, args ...interface{}) {
 	if DebugOn {
 		content := fmt.Sprintf(format, args...)
@@ -25,7 +27,7 @@ func DEBUG(format string, args ...interface{}) {
 			lines[i] = "DEBUG> " + line
 		}
 		content = strings.Join(lines, "\n")
-		printfStdErr("%s\n", content)
+		PrintfStdErr("%s\n", content)
 	}
 }
 
@@ -38,6 +40,6 @@ func TRACE(format string, args ...interface{}) {
 			lines[i] = "-----> " + line
 		}
 		content = strings.Join(lines, "\n")
-		printfStdErr("%s\n", content)
+		PrintfStdErr("%s\n", content)
 	}
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestDebug(t *testing.T) {
 	var stderr string
-	printfStdErr = func(format string, args ...interface{}) {
+	PrintfStdErr = func(format string, args ...interface{}) {
 		stderr = fmt.Sprintf(format, args...)
 	}
 	Convey("debug", t, func() {

--- a/merge.go
+++ b/merge.go
@@ -282,10 +282,21 @@ func (m *Merger) mergeArray(orig []interface{}, n []interface{}, node string) []
 // the array
 func (m *Merger) mergeArrayDefault(orig []interface{}, n []interface{}, node string) []interface{} {
 	DEBUG("%s: performing index-based array merge", node)
-	if err := canKeyMergeArray("original", orig, node, "name"); err == nil {
-		if err := canKeyMergeArray("new", n, node, "name"); err == nil {
+	var err error
+	if err = canKeyMergeArray("original", orig, node, "name"); err == nil {
+		if err = canKeyMergeArray("new", n, node, "name"); err == nil {
 			return m.mergeArrayByKey(orig, n, node, "name")
 		}
+	}
+
+	//Warn the user about any unintuitive behavior that may have gotten us here.
+	if warning, isWarning := err.(WarningError); isWarning && warning.HasContext(eContextDefaultMerge) {
+		mergeStratStr := "inline"
+		if m.AppendByDefault {
+			mergeStratStr = "append"
+		}
+		warning.SetWarning(ansi.Sprintf("%s\n  @Y{Falling back to %s merge strategy}", warning.Error(), mergeStratStr))
+		warning.Warn()
 	}
 
 	if m.AppendByDefault {
@@ -493,15 +504,23 @@ func canKeyMergeArray(disp string, array []interface{}, node string, key string)
 
 	for i, o := range array {
 		if o == nil {
-			return ansi.Errorf("@m{%s.%d}: @R{%s object is nil - cannot merge using keys}", node, i, disp)
+			return ansi.Errorf("@m{%s.%d}: @R{%s object is nil - cannot merge by key}", node, i, disp)
 		}
 		if reflect.TypeOf(o).Kind() != reflect.Map {
-			return ansi.Errorf("@m{%s.%d}: @R{%s object is a} @c{%s}@R{, not a} @c{map} @R{- cannot merge using keys}", node, i, disp, reflect.TypeOf(o).Kind().String())
+			return ansi.Errorf("@m{%s.%d}: @R{%s object is a} @c{%s}@R{, not a} @c{map} @R{- cannot merge by key}", node, i, disp, reflect.TypeOf(o).Kind().String())
 		}
 
 		obj := o.(map[interface{}]interface{})
 		if _, ok := obj[key]; !ok {
-			return ansi.Errorf("@m{%s.%d}: @R{%s object does not contain the key} @c{'%s'}@R{ - cannot merge}", node, i, disp, key)
+			return ansi.Errorf("@m{%s.%d}: @R{%s object does not contain the key} @c{'%s'}@R{ - cannot merge by key}", node, i, disp, key)
+		}
+
+		//Verify that the target key has a hashable value (i.e. a value that is not itself a hash or sequence)
+		targetValue := obj[key]
+		_, isMap := targetValue.(map[interface{}]interface{})
+		_, isSlice := targetValue.([]interface{})
+		if isMap || isSlice {
+			return NewWarningError(eContextDefaultMerge, ansi.Sprintf("@m{%s.%d}: @R{%s object's key} @c{'%s'} @R{cannot have a value which is a hash or sequence - cannot merge by key}", node, i, disp, key))
 		}
 	}
 	return nil

--- a/operator.go
+++ b/operator.go
@@ -170,7 +170,7 @@ func (e *Expr) Reduce() (*Expr, error) {
 
 	reduced, short, more := reduce(e)
 	if more && short != nil {
-		return reduced, ansi.Errorf("@R{literal} @c{%v} @R{short-circuits expression (}@c{%s}@R{)}", short, e)
+		return reduced, NewWarningError(eContextAll, "@R{literal} @c{%v} @R{short-circuits expression (}@c{%s}@R{)}", short, e)
 	}
 	return reduced, nil
 }
@@ -439,7 +439,11 @@ func ParseOpcall(phase OperatorPhase, src string) (*Opcall, error) {
 			TRACE("expr: pushing expression `%v' onto the operand list", e)
 			reduced, err := e.Reduce()
 			if err != nil {
-				fmt.Fprintf(os.Stdout, "warning: %s\n", err)
+				if warning, isWarning := err.(WarningError); isWarning {
+					warning.Warn()
+				} else {
+					fmt.Fprintf(os.Stdout, "warning: %s\n", err)
+				}
 			}
 			args = append(args, reduced)
 		}


### PR DESCRIPTION
Fixes #172 
If implicit merge got us here, a warning is given, and it falls back to an inline strategy.
If explicitly stated to merge, an error is given.
A new WarningError object with a regulated warning output was made to facilitate this. The operator warnings were updated to use this.
Warnings can be silenced from the code, so no more warnings from passing tests!
Tests were added.
Log library scope changes to facilitate testing with new warning system.