### PR TITLE
Allow use environment variables with dots

### DIFF
--- a/operator.go
+++ b/operator.go
@@ -332,7 +332,7 @@ func ParseOpcall(phase OperatorPhase, src string) (*Opcall, error) {
 		qstring := regexp.MustCompile(`(?s)^"(.*)"$`)
 		integer := regexp.MustCompile(`^[+-]?\d+(\.\d+)?$`)
 		float := regexp.MustCompile(`^[+-]?\d*\.\d+$`)
-		envvar := regexp.MustCompile(`^\$[a-zA-Z_][a-zA-Z0-9_]*$`)
+		envvar := regexp.MustCompile(`^\$[a-zA-Z_][a-zA-Z0-9_.]*$`)
 
 		var final []*Expr
 		var left, op *Expr

--- a/operator_test.go
+++ b/operator_test.go
@@ -174,12 +174,14 @@ func TestOperators(t *testing.T) {
 				os.Setenv("_SPRUCE", "_sprucify!")
 				os.Setenv("ENOENT", "")
 				os.Setenv("http_proxy", "no://thank/you")
+				os.Setenv("variable.with.dots", "dots are ok")
 
 				opOk(`(( null $SPRUCE_FOO ))`, "null", env("SPRUCE"))
 				opOk(`(( null $_SPRUCE ))`, "null", env("_SPRUCE"))
 				opOk(`(( null $ENOENT || $SPRUCE_FOO ))`, "null",
 					or(env("ENOENT"), env("SPRUCE_FOO")))
 				opOk(`(( null $http_proxy))`, "null", env("http_proxy"))
+				opOk(`(( null $variable.with.dots ))`, "null", env("variable.with.dots"))
 			})
 
 			Convey("throws errors for malformed expression", func() {


### PR DESCRIPTION
Environment variables can contain dots in the name. Usually shells
do not support them properly, but some applications might define
variables using dots.

Example use case: use unicreds[1] (golang credstash clone) to download
and call spruce:

    unicreds -t credstash exec spruce merge file.yml

[1] https://github.com/Versent/unicreds