### PR TITLE
Document + test `((!...))` syntax for credhub passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,23 @@ top:
 ```
 
 
+### Spiff Compatibility and Credhub
+
+Pivotal wrote a thing called Credhub that uses the same syntax as
+Spruce for template expansion.  BOSH uses Credhub.  So does
+Concourse.  If you want to pass stuff through Spruce to credhub,
+just use the `((!...))` notation wherever you would use Credhub's
+`((...))` notation, like this:
+
+```
+---
+secret:
+  password: ((!credhub))
+```
+
+BOSH will handle removing the `!` for you, so this should be all
+you need!
+
 
 <a name="ex-map-replacement"></a>
 ### Map Replacement

--- a/operator_test.go
+++ b/operator_test.go
@@ -94,6 +94,12 @@ func TestOperators(t *testing.T) {
 				So(err.Error(), ShouldContainSubstring, msg)
 			}
 
+			opIgnore := func(code string) {
+				op, err := ParseOpcall(phase, code)
+				So(op, ShouldBeNil)
+				So(err, ShouldBeNil)
+			}
+
 			Convey("handles opcodes with and without arguments", func() {
 				opOk(`(( null ))`, "null")
 				opOk(`(( null 42 ))`, "null", num(42))
@@ -196,6 +202,10 @@ func TestOperators(t *testing.T) {
 
 				opErr(`(( null meta.key || || ))`,
 					`syntax error near: meta.key || ||`)
+			})
+
+			Convey("ignores spiff-like bang-notation", func() {
+				opIgnore(`((!credhub))`)
 			})
 		})
 	})


### PR DESCRIPTION
Spruce ignores `((!password))` because operators must start with
ASCII [a-zA-Z].  BOSH implemented a workaround whereby `((!...))` gets
interpreted as `((...))` to allow a bug-workaround in Spiff to make use
of Credhub.  This commit documents and tests the suitability of that
same workaround for Spruce.

(This functionality has existed, undocumented, since Spruce v0)

Fixes #216