### PR TITLE
Fix #201 by supporting `azs` key in subnets

### DIFF
--- a/assets/static_ips/multi-azs-multi-underprovision.yml
+++ b/assets/static_ips/multi-azs-multi-underprovision.yml
@@ -1,0 +1,19 @@
+
+jobs:
+- name: static_z1
+  instances: 1
+  azs: [z1, z2, z3]
+  networks:
+  - name: net1
+    static_ips: (( static_ips(16) )) # should fail saying pool is only 16 big
+                                     # definitely shouldn't say pool is 48 big
+                                     # (# azs * size of pool == 48 in this case)
+networks:
+- name: net1
+  subnets:
+  - azs: [ z1, z2, z3 ]
+    static:
+      - 10.0.0.1 - 10.0.0.15
+  - azs: [z1]
+    static:
+      - 10.1.1.1

--- a/assets/static_ips/multi-azs-multi-zone-job.yml
+++ b/assets/static_ips/multi-azs-multi-zone-job.yml
@@ -1,0 +1,21 @@
+
+jobs:
+- name: static_z1
+  instances: 2
+  azs: [z1, z2, z3]
+  networks:
+  - name: net1
+    static_ips: (( static_ips(15, 16) )) # will grab 10.1.1.1 and 10.2.2.2
+                                         # from the 2nd/3rd subnet definitions
+networks:
+- name: net1
+  subnets:
+  - azs: [ z1, z2, z3 ]
+    static:
+      - 10.0.0.1 - 10.0.0.15
+  - azs: [z1]
+    static:
+      - 10.1.1.1
+  - azs: [z2]
+    static:
+      - 10.2.2.2

--- a/assets/static_ips/multi-azs-one-zone-job.yml
+++ b/assets/static_ips/multi-azs-one-zone-job.yml
@@ -1,0 +1,25 @@
+jobs:
+- azs:
+  - z1
+  instances: 2
+  name: static_z1
+  networks:
+  - name: net1
+    static_ips: (( static_ips(0, 15) ))
+networks:
+- name: net1
+  subnets:
+  - azs:
+    - z1
+    - z2
+    - z3
+    static:
+    - 10.0.0.1 - 10.0.0.15
+  - azs:
+    - z1
+    static:
+    - 10.1.1.1
+  - azs:
+    - z2
+    static:
+    - 10.2.2.2

--- a/assets/static_ips/multi-azs-same-index-different-ip.yml
+++ b/assets/static_ips/multi-azs-same-index-different-ip.yml
@@ -1,0 +1,26 @@
+
+jobs:
+- name: static_z1
+  instances: 1
+  azs: [z1]
+  networks:
+  - name: net1
+    static_ips: (( static_ips(15) ))
+- name: static_z2
+  instances: 1
+  azs: [z2]
+  networks:
+    - name: net1
+      static_ips: (( static_ips(15) ))
+networks:
+- name: net1
+  subnets:
+  - azs: [ z1, z2, z3 ]
+    static:
+      - 10.0.0.1 - 10.0.0.15
+  - azs: [z1]
+    static:
+      - 10.1.1.1
+  - azs: [z2]
+    static:
+      - 10.2.2.2

--- a/assets/static_ips/multi-azs-same-ip-different-index.yml
+++ b/assets/static_ips/multi-azs-same-ip-different-index.yml
@@ -1,0 +1,26 @@
+
+jobs:
+- name: static_z1
+  instances: 1
+  azs: [z1, z2, z3]
+  networks:
+  - name: net1
+    static_ips: (( static_ips(16) ))
+- name: static_z2
+  instances: 1
+  azs: [z2]
+  networks:
+    - name: net1
+      static_ips: (( static_ips(15) ))
+networks:
+- name: net1
+  subnets:
+  - azs: [ z1, z2, z3 ]
+    static:
+      - 10.0.0.1 - 10.0.0.15
+  - azs: [z1]
+    static:
+      - 10.1.1.1
+  - azs: [z2]
+    static:
+      - 10.2.2.2

--- a/assets/static_ips/multi-azs-same-ip-different-zones.yml
+++ b/assets/static_ips/multi-azs-same-ip-different-zones.yml
@@ -1,0 +1,26 @@
+
+jobs:
+- name: static_z1
+  instances: 1
+  azs: [z1]
+  networks:
+  - name: net1
+    static_ips: (( static_ips(14) ))
+- name: static_z2
+  instances: 1
+  azs: [z2]
+  networks:
+    - name: net1
+      static_ips: (( static_ips(14) ))
+networks:
+- name: net1
+  subnets:
+  - azs: [ z1, z2, z3 ]
+    static:
+      - 10.0.0.1 - 10.0.0.15
+  - azs: [z1]
+    static:
+      - 10.1.1.1
+  - azs: [z2]
+    static:
+      - 10.2.2.2

--- a/assets/static_ips/multi-azs-z2-underprovision.yml
+++ b/assets/static_ips/multi-azs-z2-underprovision.yml
@@ -1,0 +1,18 @@
+
+jobs:
+- name: static_z1
+  instances: 1
+  azs: [z2]
+  networks:
+  - name: net1
+    static_ips: (( static_ips(15) )) # should fail to grab 10.1.1.1, giving
+                                     # an index offset error - z2 only has 15 IPs
+networks:
+- name: net1
+  subnets:
+  - azs: [ z1, z2, z3 ]
+    static:
+      - 10.0.0.1 - 10.0.0.15
+  - azs: [z1]
+    static:
+      - 10.1.1.1

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,20 @@
+# Bug Fixes
+
+- Fixes #201 by supporting `azs` key in subnets
+
+  Previously only `az` was supported. Now when specifying
+  multiple AZs in a subnet, all IPs from that subnet can be
+  used in any instance-group/job that is in a zone that the
+  subnet mentioned.
+
+  This can lead to interesting scenarios when using mixes of
+  multi-az subnets and single-az subnets, where different offsets
+  can mean the same IP in a different zone, or the same index could
+  mean different IPs in different zones. Try not to do this, as it will
+  likely lead to confusion down the road. However, care is made to ensure
+  that IPs are never re-used, regardless of what subnets/azs they were
+  allowed to be used by.
+
+  This should not affect any existing IP allocations, since previously the
+  `azs` field wasn't looked at, and the old behaviors remain the same
+  for `az` and no-azs.


### PR DESCRIPTION
Previously only `az` was supported. Now when specifying
multiple AZs in a subnet, all IPs from that subnet can be
used in any instance_group/job that is in a zone that the
subnet mentioned.

This can lead to interesting scenarios when using mixes of
multi-az subnets and single-az subnets, where different offsets
can mean the same IP in a different zone, or the same index could
mean different IPs in different zones. Try not to do this, as it will
likely lead to confusion down the road. However, care is made to ensure
that IPs are never re-used, regardless of what subnets/azs they were
allowed to be used by.

This should not affect any existing IP allocations, since previously the
`azs` field wasn't looked at, and the old behaviors remain the same
for `az` and no-azs.