### PR TITLE
Attempt to unmarshall environment variables

### DIFF
--- a/operator.go
+++ b/operator.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strconv"
 
+	"github.com/geofffranks/yaml"
 	"github.com/starkandwayne/goutils/ansi"
 
 	. "github.com/geofffranks/spruce/log"
@@ -186,7 +187,13 @@ func (e *Expr) Resolve(tree map[interface{}]interface{}) (*Expr, error) {
 		if v == "" {
 			return nil, ansi.Errorf("@R{Environment variable} @c{$%s} @R{is not set}", e.Name)
 		}
-		return &Expr{Type: Literal, Literal: v}, nil
+
+		var val interface{}
+		err := yaml.Unmarshal([]byte(v), &val)
+		if err != nil {
+			return &Expr{Type: Literal, Literal: v}, nil
+		}
+		return &Expr{Type: Literal, Literal: val}, nil
 
 	case Reference:
 		if _, err := e.Reference.Resolve(tree); err != nil {

--- a/operator_test.go
+++ b/operator_test.go
@@ -514,6 +514,7 @@ meta:
 		os.Setenv("GRAB_ONE", "one")
 		os.Setenv("GRAB_TWO", "two")
 		os.Setenv("GRAB_NOT", "")
+		os.Setenv("GRAB_BOOL", "true")
 
 		Convey("can grab a single environment value", func() {
 			r, err := op.Run(ev, []*Expr{
@@ -535,6 +536,17 @@ meta:
 
 			So(r.Type, ShouldEqual, Replace)
 			So(r.Value.(string), ShouldEqual, "two")
+		})
+
+		Convey("unmarshalls variable contents", func() {
+			r, err := op.Run(ev, []*Expr{
+				env("GRAB_BOOL"),
+			})
+			So(err, ShouldBeNil)
+			So(r, ShouldNotBeNil)
+
+			So(r.Type, ShouldEqual, Replace)
+			So(r.Value.(bool), ShouldEqual, true)
 		})
 
 		Convey("throws errors for unset environment variables", func() {


### PR DESCRIPTION
This lets us grab booleans from the environment for yaml consumers
that are particular about value types.

Fixes #231 

Again, I'm very, very new to Go. Improvement suggestions are happily accepted.