### PR TITLE
Fix (( prune )) operator might remove the wrong element

### DIFF
--- a/assets/prune/issue-250/fileA.yml
+++ b/assets/prune/issue-250/fileA.yml
@@ -1,0 +1,11 @@
+---
+list:
+- name: one
+  params:
+    preload: true
+    fail-fast: false
+
+- name: two
+  params:
+    preload: true
+    fail-fast: false

--- a/assets/prune/issue-250/fileB.yml
+++ b/assets/prune/issue-250/fileB.yml
@@ -1,0 +1,12 @@
+---
+list:
+- name: two
+  params:
+    preload: false
+    fail-fast: (( prune ))
+
+- (( prepend ))
+- name: zero
+  params:
+    preload: true
+    fail-fast: false

--- a/cmd/spruce/main_test.go
+++ b/cmd/spruce/main_test.go
@@ -851,6 +851,29 @@ quux: quux
 `)
 		})
 
+		Convey("Text needed", func() {
+			os.Args = []string{"spruce", "merge", "../../assets/prune/issue-250/fileA.yml", "../../assets/prune/issue-250/fileB.yml"}
+			stdout = ""
+			stderr = ""
+
+			main()
+			So(stderr, ShouldEqual, "")
+			So(stdout, ShouldEqual, `list:
+- name: zero
+  params:
+    fail-fast: false
+    preload: true
+- name: one
+  params:
+    fail-fast: false
+    preload: true
+- name: two
+  params:
+    preload: false
+
+`)
+		})
+
 		Convey("Issue #156 Can use concat with static ips", func() {
 			os.Args = []string{"spruce", "merge", "../../assets/static_ips/issue-156/concat.yml"}
 			stdout = ""

--- a/merge.go
+++ b/merge.go
@@ -351,7 +351,7 @@ func (m *Merger) mergeArrayByKey(orig []interface{}, n []interface{}, node strin
 	}
 	for i, o := range orig {
 		obj := o.(map[interface{}]interface{})
-		path := fmt.Sprintf("%s.%d", node, i)
+		path := fmt.Sprintf("%s.%s", node, obj[key])
 		if _, ok := newMap[obj[key]]; ok {
 			merged[i] = m.mergeObj(obj, newMap[obj[key]], path)
 			delete(newMap, obj[key])

--- a/merge_test.go
+++ b/merge_test.go
@@ -1102,7 +1102,7 @@ func TestMergeArray(t *testing.T) {
 				m.mergeArray(orig, array, "node-path")
 				err := m.Error()
 				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldContainSubstring, "node-path.0.val.0: new object is a string, not a map - cannot merge by key")
+				So(err.Error(), ShouldContainSubstring, "node-path.first.val.0: new object is a string, not a map - cannot merge by key")
 			})
 		})
 		Convey("arrays of maps can be merged inline", func() {


### PR DESCRIPTION
Added a test case to the main test cases list, which merges two files from a assets directory to show that: If you add a `(( prune ))` in a list of maps structure that is later merged with another file, which itself changes the order in that list, you will end up deleting the wrong parts of the YAML structure: https://play.spruce.cf/#06832a74c691b5eaf823edfb702a9f41

In order to fix the prune in list of maps structure problem, we have to store the path not by using the index of the list entry, but rather the actual key name that identifies the list entry. However, this breaks another test case that checks for a specific string. That's why the other test case was modified in order to check for the path using the key name in it.

This should fix #250 