### PR TITLE
🌲 Modifying delete operator to support simple list deletion

### DIFF
--- a/assets/delete/simple-string-fileA.yml
+++ b/assets/delete/simple-string-fileA.yml
@@ -1,0 +1,8 @@
+---
+meta:
+  list:
+  - one
+  - two
+  - three
+  - four
+  - five

--- a/assets/delete/simple-string-fileB.yml
+++ b/assets/delete/simple-string-fileB.yml
@@ -1,0 +1,5 @@
+---
+meta:
+  list:
+  - (( delete "three" ))
+  - (( delete four ))

--- a/assets/delete/text-fileA.yml
+++ b/assets/delete/text-fileA.yml
@@ -1,0 +1,23 @@
+---
+meta:
+  list:
+  - Leonel Messi
+  - Cristiano Ronaldo
+  - Oliver Kahn
+
+stuff:
+  default_groups:
+  - openid
+  - cloud_controller.read
+  - cloud_controller.write
+  - password.write
+  - uaa.user
+  - approvals.me
+  - profile
+  - roles
+  - user_attributes
+  - uaa.offline_token
+  environment_scripts:
+  - scripts/configure-HA-hosts.sh
+  - scripts/forward_logfiles.sh
+  - scripts/patches/cc_clock_wait_for_api_ready.sh

--- a/assets/delete/text-fileB.yml
+++ b/assets/delete/text-fileB.yml
@@ -1,0 +1,12 @@
+---
+meta:
+  list:
+  - (( delete "Cristiano Ronaldo" ))
+
+stuff:
+  default_groups:
+  - (( delete password.write ))
+  - (( delete "cloud_controller.write"))
+
+  environment_scripts:
+  - (( delete scripts/patches/cc_clock_wait_for_api_ready.sh ))

--- a/cmd/spruce/main_test.go
+++ b/cmd/spruce/main_test.go
@@ -874,6 +874,50 @@ quux: quux
 `)
 		})
 
+		Convey("The delete operator deletes an entry in a simple list", func() {
+			os.Args = []string{"spruce", "merge", "../../assets/delete/simple-string-fileA.yml", "../../assets/delete/simple-string-fileB.yml"}
+			stdout = ""
+			stderr = ""
+
+			main()
+			So(stderr, ShouldEqual, "")
+			So(stdout, ShouldEqual, `meta:
+  list:
+  - one
+  - two
+  - five
+
+`)
+		})
+
+		Convey("The delete operator deletes an entry with whitespaces or special characters in a simple list", func() {
+			os.Args = []string{"spruce", "merge", "../../assets/delete/text-fileA.yml", "../../assets/delete/text-fileB.yml"}
+			stdout = ""
+			stderr = ""
+
+			main()
+			So(stderr, ShouldEqual, "")
+			So(stdout, ShouldEqual, `meta:
+  list:
+  - Leonel Messi
+  - Oliver Kahn
+stuff:
+  default_groups:
+  - openid
+  - cloud_controller.read
+  - uaa.user
+  - approvals.me
+  - profile
+  - roles
+  - user_attributes
+  - uaa.offline_token
+  environment_scripts:
+  - scripts/configure-HA-hosts.sh
+  - scripts/forward_logfiles.sh
+
+`)
+		})
+
 		Convey("Issue #156 Can use concat with static ips", func() {
 			os.Args = []string{"spruce", "merge", "../../assets/static_ips/issue-156/concat.yml"}
 			stdout = ""


### PR DESCRIPTION
 Modifying delete operator to support simple list deletion based on the value name.

This includes the following:
- delete operator remains the same, but now will also delete from simple list(list of strings)
- includes test cases for both main and merge tests
- New test files included, under assets/delete

Signed-off-by: EEE <encalada@de.ibm.com>