### PR TITLE
Support SOCKS5 proxy

### DIFF
--- a/op_vault.go
+++ b/op_vault.go
@@ -222,6 +222,7 @@ func getVaultSecret(secret string) (map[string]interface{}, error) {
 
 	client := &http.Client{
 		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				RootCAs:            roots,
 				InsecureSkipVerify: skipVaultVerify(os.Getenv("VAULT_SKIP_VERIFY")),


### PR DESCRIPTION
I'd like to use spruce from in front of a SOCKS5 jumpbox. 

I tried `HTTPS_PROXY` but it blocks:

```
HTTPS_PROXY=$BOSH_ALL_PROXY spruce merge test.yml
```

I've borrowed the Golang 1.9/1.10 technique used in `safe` -
 https://github.com/starkandwayne/safe/blob/cd8736bbffdee5d4b32960393d23719741834023/auth/auth.go#L28 to use Golang's `HTTPS_PROXY` support.

Testing:

```
$ cat test.yml
serial: (( vault "secret/useast2/dev/vault/certs/ca:serial" ))
$ HTTPS_PROXY=$BOSH_ALL_PROXY go run cmd/spruce/main.go merge test.yml
serial: 3
```