### PR TITLE
Support building snap packages for Linux distros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ artifacts
 .svtoken
 *.swp
 .vscode
+parts/
+prime/
+stage/
+snap/.snapcraft/
+*.snap

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,7 @@ clitests: build
 
 build:
 	go build ./cmd/spruce
+
+.PHONY: snap
+snap:
+	snapcraft

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,27 @@
+name: spruce
+version: git
+summary: A general purpose YAML & JSON merging tool.
+description: |
+  Spruce is a general purpose YAML & JSON merging tool.
+  It is designed to be an intuitive utility for merging YAML/JSON templates
+  together to generate complicated YAML/JSON config files in a
+  repeatable fashion. It can be used to stitch together some generic/top level
+  definitions for the config and pull in overrides for site-specific
+  configurations to DRY your configs up as much as possible.
+
+grade: stable
+confinement: strict
+
+parts:
+  spruce:
+    source: .
+    plugin: go
+    go-importpath: github.com/geofffranks/spruce
+    after: [go]
+  go:
+    source-tag: go1.9.4
+
+apps:
+  spruce:
+    command: spruce
+    plugs: [home]


### PR DESCRIPTION
Snaps are a new packaging format for Linux distributions. They originated on Ubuntu, but support multiple Linux distributions. It would be wonderful if snap packages could be published with new releases of `spruce`, like with brew packages. There is a link to the snap publishing page at the end of the PR.

This PR adds a snap/snapcraft.yaml file, allowing a snap package to be build by running:

```bash
make snap
```

This make target requires that snapcraft is installed. On Ubuntu, it can be installed by `snap install snapcraft --classic`, and on MacOS it can be installed by `brew install snapcraft`. Please note I've only tested this on Ubuntu.

If the snap package is published to the Ubuntu Snap Store, then users can install with:

```bash
snap install spruce
```

The `spruce` snap package uses strict confinement, meaning the `spruce` snap has restricted access to the host system. A home plug has been added, allowing the `spruce` snap package to access files in the users home directory. The `spruce` command, when installed as a snap, will not be able to read files outside of the user's home directory.

Useful links:

Building Go snaps: https://docs.snapcraft.io/build-snaps/go

Publishing a snap package: https://docs.snapcraft.io/build-snaps/publish

Integrating publishing with GitHub: https://build.snapcraft.io/

Snaps support release channels, such as `stable` for releases and `edge` for nightly releases. I think you can create other channels, too. You may want to publish release to the stable channel, and periodically publish the HEAD of the master branch to the edge channel. This will allow users to choose which between stable and pre-release versions of `spruce`.