### PR TITLE
Fix TYPOs in Go source files

### DIFF
--- a/evaluator.go
+++ b/evaluator.go
@@ -258,7 +258,7 @@ func (ev *Evaluator) DataFlow(phase OperatorPhase) ([]*Opcall, error) {
 	}
 	sort.Strings(sortedKeys)
 
-	// find all nodes in g that are free (no futher dependencies)
+	// find all nodes in g that are free (no further dependencies)
 	freeNodes := func(g [][]*Opcall) []*Opcall {
 		l := []*Opcall{}
 		for _, k := range sortedKeys {

--- a/op_calc.go
+++ b/op_calc.go
@@ -100,11 +100,11 @@ func (CalcOperator) Run(ev *Evaluator, args []*Expr) (*Response, error) {
 func searchForCursors(input string) ([]*tree.Cursor, error) {
 	result := []*tree.Cursor{}
 
-	// Search for sub-strings that contain the path seperator dot character
+	// Search for sub-strings that contain the path separator dot character
 	// https://regex101.com/r/TIEyak/1 (to delete the URL use https://regex101.com/delete/fPbxosYXWzBPYaNdL5YcPpj3)
 	regexp := regexp.MustCompile(`(\w+|-)\.(\w+|-|\.)+`)
 	candidates := regexp.FindAllString(input, -1)
-	DEBUG("    strings found containing the path seperator: %v", strings.Join(candidates, ", "))
+	DEBUG("    strings found containing the path separator: %v", strings.Join(candidates, ", "))
 
 	// If it is a path, it can be parsed (parse errors will be ignored)
 	for _, candidate := range candidates {

--- a/op_join.go
+++ b/op_join.go
@@ -107,11 +107,11 @@ func (JoinOperator) Run(ev *Evaluator, args []*Expr) (*Response, error) {
 		return nil, ansi.Errorf("too few arguments supplied to @c{(( join ... ))}")
 	}
 
-	var seperator string
+	var separator string
 	var list []string
 
 	for i, arg := range args {
-		if i == 0 { // argument #0: seperator
+		if i == 0 { // argument #0: separator
 			sep, err := arg.Resolve(ev.Tree)
 			if err != nil {
 				DEBUG("     [%d]: resolution failed\n    error: %s", i, err)
@@ -119,12 +119,12 @@ func (JoinOperator) Run(ev *Evaluator, args []*Expr) (*Response, error) {
 			}
 
 			if sep.Type != Literal {
-				DEBUG("     [%d]: unsupported type for join operator seperator argument: '%v'", i, sep)
-				return nil, fmt.Errorf("join operator only accepts literal argument for the seperator")
+				DEBUG("     [%d]: unsupported type for join operator separator argument: '%v'", i, sep)
+				return nil, fmt.Errorf("join operator only accepts literal argument for the separator")
 			}
 
-			DEBUG("     [%d]: list seperator will be: %s", i, sep)
-			seperator = sep.Literal.(string)
+			DEBUG("     [%d]: list separator will be: %s", i, sep)
+			separator = sep.Literal.(string)
 
 		} else { // argument #1..n: list, or literal
 			ref, err := arg.Resolve(ev.Tree)
@@ -181,10 +181,10 @@ func (JoinOperator) Run(ev *Evaluator, args []*Expr) (*Response, error) {
 	}
 
 	// finally, join and return
-	DEBUG("  joined list: %s", strings.Join(list, seperator))
+	DEBUG("  joined list: %s", strings.Join(list, separator))
 	return &Response{
 		Type:  Replace,
-		Value: strings.Join(list, seperator),
+		Value: strings.Join(list, separator),
 	}, nil
 }
 

--- a/operator_test.go
+++ b/operator_test.go
@@ -1496,13 +1496,13 @@ meta:
 			So(r, ShouldBeNil)
 		})
 
-		Convey("throws an error when seperator argument is not a literal", func() {
+		Convey("throws an error when separator argument is not a literal", func() {
 			r, err := op.Run(ev, []*Expr{
 				ref("meta.emptylist"),
 				ref("meta.authorities"),
 			})
 			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldContainSubstring, "join operator only accepts literal argument for the seperator")
+			So(err.Error(), ShouldContainSubstring, "join operator only accepts literal argument for the separator")
 			So(r, ShouldBeNil)
 		})
 


### PR DESCRIPTION
Playing around with [goreportcard.com](https://goreportcard.com/report/github.com/geofffranks/spruce), I realized that I am the author of the majority of misspellings in Spruce :)

That's why I replaced all instances of copy&paste separator TYPO that I introduced
some time ago. Also I fixed one other TYPO found by [misspell](https://github.com/client9/misspell/cmd/misspell).