### PR TITLE
Add (( sort )) operator

### DIFF
--- a/assets/sort/base.yml
+++ b/assets/sort/base.yml
@@ -1,0 +1,87 @@
+---
+name_list:
+- name: item-z
+- name: item-y
+- name: item-x
+- name: item-w
+- name: item-v
+- name: item-u
+- name: item-t
+- name: item-s
+- name: item-r
+- name: item-q
+- name: item-p
+- name: item-o
+- name: item-n
+- name: item-m
+- name: item-l
+- name: item-k
+- name: item-j
+- name: item-i
+- name: item-h
+- name: item-g
+- name: item-f
+- name: item-e
+- name: item-d
+- name: item-c
+- name: item-b
+- name: item-a
+- name: item-9
+- name: item-8
+- name: item-7
+- name: item-6
+- name: item-5
+- name: item-4
+- name: item-3
+- name: item-2
+- name: item-1
+
+key_list:
+- key: item-i
+- key: item-h
+- key: item-g
+- key: item-f
+- key: item-e
+- key: item-d
+- key: item-c
+- key: item-b
+- key: item-a
+- key: item-4
+- key: item-3
+- key: item-2
+- key: item-1
+
+foobar_list:
+- foobar: item-m
+- foobar: item-l
+- foobar: item-k
+- foobar: item-j
+- foobar: item-i
+- foobar: item-h
+- foobar: item-g
+- foobar: item-9
+- foobar: item-8
+- foobar: item-7
+- foobar: item-6
+
+int_list:
+- 1
+- 9
+- 2
+- 8
+- 3
+- 7
+- 4
+- 6
+- 5
+
+float_list:
+- 1.42
+- 9.42
+- 2.42
+- 8.42
+- 3.42
+- 7.42
+- 4.42
+- 6.42
+- 5.42

--- a/assets/sort/op.yml
+++ b/assets/sort/op.yml
@@ -1,0 +1,6 @@
+---
+name_list: (( sort ))
+key_list: (( sort by key ))
+foobar_list: (( sort by foobar ))
+int_list: (( sort ))
+float_list: (( sort ))

--- a/cmd/spruce/main_test.go
+++ b/cmd/spruce/main_test.go
@@ -1318,6 +1318,100 @@ z:
 			}
 		})
 
+		Convey("Sort test cases", func() {
+			Convey("sort operator functionality", func() {
+				os.Args = []string{"spruce", "merge", "../../assets/sort/base.yml", "../../assets/sort/op.yml"}
+				stdout = ""
+				stderr = ""
+				main()
+				So(stderr, ShouldEqual, "")
+				So(stdout, ShouldEqual, `float_list:
+- 1.42
+- 2.42
+- 3.42
+- 4.42
+- 5.42
+- 6.42
+- 7.42
+- 8.42
+- 9.42
+foobar_list:
+- foobar: item-6
+- foobar: item-7
+- foobar: item-8
+- foobar: item-9
+- foobar: item-g
+- foobar: item-h
+- foobar: item-i
+- foobar: item-j
+- foobar: item-k
+- foobar: item-l
+- foobar: item-m
+int_list:
+- 1
+- 2
+- 3
+- 4
+- 5
+- 6
+- 7
+- 8
+- 9
+key_list:
+- key: item-1
+- key: item-2
+- key: item-3
+- key: item-4
+- key: item-a
+- key: item-b
+- key: item-c
+- key: item-d
+- key: item-e
+- key: item-f
+- key: item-g
+- key: item-h
+- key: item-i
+name_list:
+- name: item-1
+- name: item-2
+- name: item-3
+- name: item-4
+- name: item-5
+- name: item-6
+- name: item-7
+- name: item-8
+- name: item-9
+- name: item-a
+- name: item-b
+- name: item-c
+- name: item-d
+- name: item-e
+- name: item-f
+- name: item-g
+- name: item-h
+- name: item-i
+- name: item-j
+- name: item-k
+- name: item-l
+- name: item-m
+- name: item-n
+- name: item-o
+- name: item-p
+- name: item-q
+- name: item-r
+- name: item-s
+- name: item-t
+- name: item-u
+- name: item-v
+- name: item-w
+- name: item-x
+- name: item-y
+- name: item-z
+
+`)
+			})
+		})
+
 		Convey("Cherry picking test cases", func() {
 			Convey("Cherry pick just one root level path", func() {
 				os.Args = []string{"spruce", "merge", "--cherry-pick", "properties", "../../assets/cherry-pick/fileA.yml", "../../assets/cherry-pick/fileB.yml"}

--- a/doc/merging.md
+++ b/doc/merging.md
@@ -66,7 +66,7 @@ and multiple phases have been introduced into `spruce` to handle the various tas
 
 ## What about arrays?
 
-Merging arrays together is slightly more complicated than merging arbitray-key-values,
+Merging arrays together is slightly more complicated than merging arbitrary-key-values,
 because order matters. To aid in this, `spruce` has specific **array operators** that
 are used to tell it how to perform array merges:
 

--- a/doc/operators.md
+++ b/doc/operators.md
@@ -22,7 +22,7 @@ see the [array merging documentation][array-merging]:
 - `(( append ))` - Adds the data to the end of the corresponding array in the root document.
 - `(( prepend ))` - Inserts the data at the beginning of the corresponding array in the root document.
 - `(( insert ))` - Inserts the data before or after a specified index, or object.
-- `(( merge ))` - Merges the data on top of an existing array based on a common key. This 
+- `(( merge ))` - Merges the data on top of an existing array based on a common key. This
   requires each element to be an object, all with the common key used for merging.
 - `(( inline ))` - Merges the data ontop of an existing array, based on the indices of the
   array.
@@ -68,7 +68,7 @@ Usage: `(( concat LITERAL|REFERENCE ... ))`
 
 The `(( concat ))` operator has a role that may shock you. It concatenates values together into
 a string. You can pass it any number of arguments, literal or reference, as long as the reference
-is not an array/map. 
+is not an array/map.
 
 [Example][concat-example]
 
@@ -210,6 +210,26 @@ to rely on the end-user always specifying the necessary `--prune` flags, you can
 make use `(( prune ))`s to clear out the bloated data..
 
 [Example][prune-example]
+
+## (( sort ))
+
+Usage: `(( sort [by KEY] ))`
+
+This operator enables sorting simple lists like lists of strings, or
+numbers as well as lists of maps that follow the known contract of containing an
+identifying entry each, like `name`, `key`, or `id`. As always, `name` is the
+default for named-entry lists if no sort key is specified. The `(( sort ))`
+operator works similar to the `(( prune ))` operator as more of an annotation
+than an actual operator that immediately performs an action: The path at which
+the sort operator is used will be marked for evaluation in the post-processing
+phase. That means the sorting will only take place once after all files are
+merged.
+
+The `(( sort ))` operator will fail in case of:
+- lists that do not contain strings, numbers or maps (for example lists of lists)
+- inhomogeneous types (mixing strings and numbers)
+- named-entry maps that do not have a single identifying entry
+
 
 ## (( static_ips ))
 

--- a/evaluator.go
+++ b/evaluator.go
@@ -388,6 +388,50 @@ func (ev *Evaluator) Prune(paths []string) error {
 	return nil
 }
 
+// SortPaths sorts all paths (keys in map) using the provided sort-key (respective value)
+func (ev *Evaluator) SortPaths(pathKeyMap map[string]string) error {
+	DEBUG("sorting %d paths in the final YAML structure", len(pathKeyMap))
+	for path, sortBy := range pathKeyMap {
+		DEBUG("  sorting path %s (sort-key %s)", path, sortBy)
+
+		cursor, err := tree.ParseCursor(path)
+		if err != nil {
+			return err
+		}
+
+		value, err := cursor.Resolve(ev.Tree)
+		if err != nil {
+			return err
+		}
+
+		switch value.(type) {
+		case []interface{}:
+			// no-op, that's what we want ...
+
+		case map[interface{}]interface{}:
+			return tree.TypeMismatchError{
+				Path:   []string{path},
+				Wanted: "a list",
+				Got:    "a map",
+			}
+
+		default:
+			return tree.TypeMismatchError{
+				Path:   []string{path},
+				Wanted: "a list",
+				Got:    "a scalar",
+			}
+		}
+
+		if err := sortList(path, value.([]interface{}), sortBy); err != nil {
+			return err
+		}
+	}
+
+	DEBUG("")
+	return nil
+}
+
 // Cherry-pick ...
 func (ev *Evaluator) CherryPick(paths []string) error {
 	DEBUG("cherry-picking %d paths from the final YAML structure", len(paths))
@@ -644,6 +688,10 @@ func (ev *Evaluator) Run(prune []string, picks []string) error {
 	addToPruneListIfNecessary(prune...)
 	errors.Append(ev.Prune(keysToPrune))
 	keysToPrune = nil
+
+	// post-processing: sorting
+	errors.Append(ev.SortPaths(pathsToSort))
+	pathsToSort = map[string]string{}
 
 	// post-processing: cherry-pick
 	errors.Append(ev.CherryPick(picks))

--- a/op_sort.go
+++ b/op_sort.go
@@ -1,0 +1,139 @@
+package spruce
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	. "github.com/geofffranks/spruce/log"
+	"github.com/starkandwayne/goutils/tree"
+)
+
+var pathsToSort = map[string]string{}
+
+type itemType int
+
+const (
+	stringItems itemType = iota
+	floatItems
+	intItems
+	mapItems
+	otherItems
+)
+
+// SortOperator ...
+type SortOperator struct{}
+
+// Setup ...
+func (SortOperator) Setup() error {
+	return nil
+}
+
+// Phase ...
+func (SortOperator) Phase() OperatorPhase {
+	return MergePhase
+}
+
+// Dependencies ...
+func (SortOperator) Dependencies(_ *Evaluator, _ []*Expr, _ []*tree.Cursor, auto []*tree.Cursor) []*tree.Cursor {
+	return auto
+}
+
+// Run ...
+func (SortOperator) Run(ev *Evaluator, args []*Expr) (*Response, error) {
+	return nil, fmt.Errorf("orphaned (( sort )) operator at $.%s, no list exists at that path", ev.Here)
+}
+
+func init() {
+	RegisterOp("sort", SortOperator{})
+}
+
+func addToSortListIfNecessary(operator string, path string) {
+	if opcall, err := ParseOpcall(MergePhase, operator); err == nil {
+		var byKey string
+		if len(opcall.args) == 2 {
+			byKey = opcall.args[1].String()
+		}
+
+		DEBUG("adding sort by '%s' of path '%s' to the list of paths to sort", byKey, path)
+		if _, ok := pathsToSort[path]; !ok {
+			pathsToSort[path] = byKey
+		}
+	}
+}
+
+func universalLess(a interface{}, b interface{}, key string) bool {
+	switch a.(type) {
+	case string:
+		return strings.Compare(a.(string), b.(string)) < 0
+
+	case float64:
+		return a.(float64) < b.(float64)
+
+	case int:
+		return a.(int) < b.(int)
+
+	case map[interface{}]interface{}:
+		entryA, entryB := a.(map[interface{}]interface{}), b.(map[interface{}]interface{})
+		return universalLess(entryA[key], entryB[key], key)
+	}
+
+	return false
+}
+
+func sortList(path string, list []interface{}, key string) error {
+	typeCheckMap := map[string]struct{}{}
+	for _, entry := range list {
+		reflectType := reflect.TypeOf(entry)
+
+		var typeName string
+		if reflectType != nil {
+			typeName = reflectType.Kind().String()
+		} else {
+			typeName = "nil"
+		}
+
+		if _, ok := typeCheckMap[typeName]; !ok {
+			typeCheckMap[typeName] = struct{}{}
+		}
+	}
+
+	if length := len(typeCheckMap); length > 0 && length != 1 {
+		return tree.TypeMismatchError{
+			Path:   []string{path},
+			Wanted: "a list with homogeneous entry types",
+			Got:    "a list with different types",
+		}
+	}
+
+	for kind := range typeCheckMap {
+		switch kind {
+		case reflect.Map.String():
+			if key == "" {
+				key = "name"
+			}
+
+			if err := canKeyMergeArray("list", list, path, key); err != nil {
+				return tree.TypeMismatchError{
+					Path:   []string{path},
+					Wanted: fmt.Sprintf("a list with map entries each containing %s", key),
+					Got:    fmt.Sprintf("a list with map entries, where some do not contain %s", key),
+				}
+			}
+
+		case reflect.Slice.String():
+			return tree.TypeMismatchError{
+				Path:   []string{path},
+				Wanted: fmt.Sprintf("a list with maps, strings or numbers"),
+				Got:    fmt.Sprintf("a list with list entries"),
+			}
+		}
+	}
+
+	sort.Slice(list, func(i int, j int) bool {
+		return universalLess(list[i], list[j], key)
+	})
+
+	return nil
+}

--- a/sort_test.go
+++ b/sort_test.go
@@ -1,0 +1,96 @@
+package spruce
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/starkandwayne/goutils/tree"
+)
+
+func TestSort(t *testing.T) {
+	Convey("that the actual Run function of the sort operator is dead code", t, func() {
+		op := &SortOperator{}
+		ev := &Evaluator{Here: &tree.Cursor{Nodes: []string{"foobar"}}}
+
+		resp, err := op.Run(ev, []*Expr{})
+		So(resp, ShouldBeNil)
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldResemble, "orphaned (( sort )) operator at $.foobar, no list exists at that path")
+	})
+
+	Convey("that sorting an empty list returns an empty list", t, func() {
+		list := []interface{}{}
+		err := sortList("some.path", list, "")
+		So(err, ShouldBeNil)
+		So(list, ShouldResemble, []interface{}{})
+	})
+
+	Convey("that sorting of integers works", t, func() {
+		list := []interface{}{2, 1}
+		err := sortList("some.path", list, "")
+		So(err, ShouldBeNil)
+		So(list, ShouldResemble, []interface{}{1, 2})
+	})
+
+	Convey("that sorting of floats works", t, func() {
+		list := []interface{}{2.0, 1.0}
+		err := sortList("some.path", list, "")
+		So(err, ShouldBeNil)
+		So(list, ShouldResemble, []interface{}{1.0, 2.0})
+	})
+
+	Convey("that sorting of strings works", t, func() {
+		list := []interface{}{"spruce", "spiff"}
+		err := sortList("some.path", list, "")
+		So(err, ShouldBeNil)
+		So(list, ShouldResemble, []interface{}{"spiff", "spruce"})
+	})
+
+	Convey("that sorting of named-entry lists works", t, func() {
+		list := []interface{}{
+			map[interface{}]interface{}{"name": "B"},
+			map[interface{}]interface{}{"name": "A"},
+		}
+		err := sortList("some.path", list, "")
+		So(err, ShouldBeNil)
+		So(list, ShouldResemble, []interface{}{
+			map[interface{}]interface{}{"name": "A"},
+			map[interface{}]interface{}{"name": "B"},
+		})
+	})
+
+	Convey("that sorting of lists of lists fails", t, func() {
+		list := []interface{}{
+			[]interface{}{"B", "A"},
+			[]interface{}{"A", "B"},
+		}
+
+		err := sortList("some.path", list, "")
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldResemble, "$.some.path is a list with list entries (not a list with maps, strings or numbers)")
+	})
+
+	Convey("that sorting of a list of inhomogeneous types fails", t, func() {
+		list := []interface{}{42, 42.0, "42"}
+		err := sortList("some.path", list, "")
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldResemble, "$.some.path is a list with different types (not a list with homogeneous entry types)")
+	})
+
+	Convey("that sorting of a list with nil values fails (by definition considered to be inhomogeneous types)", t, func() {
+		list := []interface{}{"A", "B", "C", nil}
+		err := sortList("some.path", list, "")
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldResemble, "$.some.path is a list with different types (not a list with homogeneous entry types)")
+	})
+
+	Convey("that sorting of a named-entry list with inconsistent identifier fails", t, func() {
+		list := []interface{}{
+			map[interface{}]interface{}{"foo": "one"},
+			map[interface{}]interface{}{"key": "two"},
+		}
+		err := sortList("some.path", list, "foo")
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldResemble, "$.some.path is a list with map entries, where some do not contain foo (not a list with map entries each containing foo)")
+	})
+}


### PR DESCRIPTION
Introduce `(( sort ))` operator to enable sorting in post-processing of paths
that lead to lists of strings, lists of numbers or named-entry maps.

This is related to the [question that @qu1queee had some time ago](https://cloudfoundry.slack.com/archives/C26FF0W5B/p1518625467000890) in #spruce.