### PR TITLE
Fix implicit/default merge behaves different than explicit merge 

### DIFF
--- a/assets/issue-267/option1-fileA.yml
+++ b/assets/issue-267/option1-fileA.yml
@@ -1,0 +1,6 @@
+---
+serverFiles:
+  prometheus.yml:
+    scrape_configs:
+    - name: zero
+    - name: one

--- a/assets/issue-267/option1-fileB.yml
+++ b/assets/issue-267/option1-fileB.yml
@@ -1,0 +1,7 @@
+---
+serverFiles:
+  prometheus.yml:
+    scrape_configs:
+    - name: two
+    - (( delete name "zero" ))
+

--- a/assets/issue-267/option2-fileA.yml
+++ b/assets/issue-267/option2-fileA.yml
@@ -1,0 +1,6 @@
+---
+serverFiles:
+  prometheus.yml:
+    scrape_configs:
+    - name: zero
+    - name: one

--- a/assets/issue-267/option2-fileB.yml
+++ b/assets/issue-267/option2-fileB.yml
@@ -1,0 +1,7 @@
+---
+serverFiles:
+  prometheus.yml:
+    scrape_configs:
+    - (( merge ))
+    - name: two
+    - (( delete name "zero" ))

--- a/assets/issue-267/option3-fileA.yml
+++ b/assets/issue-267/option3-fileA.yml
@@ -1,0 +1,6 @@
+---
+serverFiles:
+  prometheus.yml:
+    scrape_configs:
+    - name: zero
+    - name: one

--- a/assets/issue-267/option3-fileB.yml
+++ b/assets/issue-267/option3-fileB.yml
@@ -1,0 +1,7 @@
+---
+serverFiles:
+  prometheus.yml:
+    scrape_configs:
+    - (( merge on name ))
+    - name: two
+    - (( delete name "zero" ))

--- a/assets/issue-267/option4-fileA.yml
+++ b/assets/issue-267/option4-fileA.yml
@@ -1,0 +1,6 @@
+---
+serverFiles:
+  prometheus.yml:
+    scrape_configs:
+    - job_name: zero
+    - job_name: one

--- a/assets/issue-267/option4-fileB.yml
+++ b/assets/issue-267/option4-fileB.yml
@@ -1,0 +1,7 @@
+---
+serverFiles:
+  prometheus.yml:
+    scrape_configs:
+    - (( merge on job_name ))
+    - job_name: two
+    - (( delete job_name "zero" ))

--- a/cmd/spruce/main_test.go
+++ b/cmd/spruce/main_test.go
@@ -1904,6 +1904,7 @@ warning: Falling back to inline merge strategy
 `)
 				So(stdout, ShouldEqual, "")
 			})
+
 			Convey("Issue #172 - error instead of panic if merge on key was specifically requested but target key has map value", func() {
 				os.Args = []string{"spruce", "merge", "../../assets/issue-172/explicitmergeonkey1.yml"}
 				stdout = ""
@@ -1980,6 +1981,73 @@ meta:
 
 `)
 		})
+
+		Convey("Issue #267 - specifying an explicit merge operator must behave in the same way as relying on the default implicit merge operation", func() {
+			Convey("Option 1 - standard use-case: no explicit merge, named-entry list identifier key is the default called 'name'", func() {
+				os.Args = []string{"spruce", "merge", "../../assets/issue-267/option1-fileA.yml", "../../assets/issue-267/option1-fileB.yml"}
+				stdout = ""
+				stderr = ""
+
+				main()
+				So(stderr, ShouldEqual, "")
+				So(stdout, ShouldEqual, `serverFiles:
+  prometheus.yml:
+    scrape_configs:
+    - name: one
+    - name: two
+
+`)
+			})
+
+			Convey("Option 2 - academic version of the option 1: same set-up, but with explicit usage of the merge operator", func() {
+				os.Args = []string{"spruce", "merge", "../../assets/issue-267/option2-fileA.yml", "../../assets/issue-267/option2-fileB.yml"}
+				stdout = ""
+				stderr = ""
+
+				main()
+				So(stderr, ShouldEqual, "")
+				So(stdout, ShouldEqual, `serverFiles:
+  prometheus.yml:
+    scrape_configs:
+    - name: one
+    - name: two
+
+`)
+			})
+
+			Convey("Option 3 - even more academic version of the option 1: same set-up, but with explicit usage of the merge operator and specification of the default identifier key called 'name'", func() {
+				os.Args = []string{"spruce", "merge", "../../assets/issue-267/option3-fileA.yml", "../../assets/issue-267/option3-fileB.yml"}
+				stdout = ""
+				stderr = ""
+
+				main()
+				So(stderr, ShouldEqual, "")
+				So(stdout, ShouldEqual, `serverFiles:
+  prometheus.yml:
+    scrape_configs:
+    - name: one
+    - name: two
+
+`)
+			})
+
+			Convey("Option 4 - actual real world use case, where the identifier key is call 'job_name' and therefore explicit merge on key is required", func() {
+				os.Args = []string{"spruce", "merge", "../../assets/issue-267/option4-fileA.yml", "../../assets/issue-267/option4-fileB.yml"}
+				stdout = ""
+				stderr = ""
+
+				main()
+				So(stderr, ShouldEqual, "")
+				So(stdout, ShouldEqual, `serverFiles:
+  prometheus.yml:
+    scrape_configs:
+    - job_name: one
+    - job_name: two
+
+`)
+			})
+		})
+
 		Convey("Support go-patch files", func() {
 			Convey("go-patch can modify yaml files in the merge phase, and insert spruce operators as required", func() {
 				os.Args = []string{"spruce", "merge", "--go-patch", "../../assets/go-patch/base.yml", "../../assets/go-patch/patch.yml", "../../assets/go-patch/toMerge.yml"}
@@ -2054,7 +2122,6 @@ spruce_array_grab:
 			os.Setenv("DEFAULT_ARRAY_MERGE_KEY", "")
 		})
 	})
-
 }
 
 func TestDebug(t *testing.T) {

--- a/merge.go
+++ b/merge.go
@@ -675,17 +675,6 @@ func canKeyMergeArray(disp string, array []interface{}, node string, key string)
 	return nil
 }
 
-func shouldReplaceArray(obj []interface{}) bool {
-	if len(obj) >= 1 && obj[0] != nil && reflect.TypeOf(obj[0]).Kind() == reflect.String {
-		re := regexp.MustCompile(`^\Q((\E\s*replace\s*\Q))\E$`)
-
-		if re.MatchString(obj[0].(string)) {
-			return true
-		}
-	}
-	return false
-}
-
 func getIndexOfSimpleEntry(list []interface{}, name string) int {
 	for i, entry := range list {
 		switch entry.(type) {

--- a/merge.go
+++ b/merge.go
@@ -445,16 +445,6 @@ func (m *Merger) mergeArrayByKey(orig []interface{}, n []interface{}, node strin
 	return merged
 }
 
-func shouldInlineMergeArray(obj []interface{}) bool {
-	if len(obj) >= 1 && obj[0] != nil && reflect.TypeOf(obj[0]).Kind() == reflect.String {
-		re := regexp.MustCompile("^\\Q((\\E\\s*inline\\s*\\Q))\\E$")
-		if re.MatchString(obj[0].(string)) {
-			return true
-		}
-	}
-	return false
-}
-
 // getArrayModifications returns a list of ModificationDefinition objects with
 // information on which array operations to apply to which entries. The first
 // object in the returned will always represent the default merge behavior.

--- a/merge_test.go
+++ b/merge_test.go
@@ -168,14 +168,14 @@ func TestGetArrayModifications(t *testing.T) {
 	}
 
 	shouldBeDelete := func(actual interface{}, _ ...interface{}) string {
-		if !actual.(ModificationDefinition).delete {
+		if actual.(ModificationDefinition).listOp != listOpDelete {
 			return "Result doesn't have marker for delete operation"
 		}
 		return ""
 	}
 
 	shouldBeDefault := func(actual interface{}, _ ...interface{}) string {
-		if actual.(ModificationDefinition).defaultMerge {
+		if actual.(ModificationDefinition).listOp == listOpMergeDefault {
 			return ""
 		}
 		return "Expected defaultMerge to be true"
@@ -410,7 +410,7 @@ func TestGetArrayModifications(t *testing.T) {
 	Convey("Don't return an insert if index is obviously out of bounds", t, func() {
 		results := getArrayModifications([]interface{}{"(( insert before -1 ))", "stuff"}, false)
 		So(results, ShouldHaveLength, 1) //Just the default merge
-		So(results[0].defaultMerge, ShouldBeTrue)
+		So(results[0].listOp, ShouldEqual, listOpMergeDefault)
 	})
 
 	Convey("If there are multiple insert token with after/before, different key names, and names (only technical usecase)", t, func() {
@@ -444,7 +444,7 @@ func TestGetArrayModifications(t *testing.T) {
 	Convey("Can specify operators without one at the 0th index", t, func() {
 		results := getArrayModifications([]interface{}{"foo", "(( append ))", "stuff"}, false)
 		So(results, ShouldHaveLength, 2)
-		So(results[0].defaultMerge, ShouldBeTrue)
+		So(results[0].listOp, ShouldEqual, listOpMergeDefault)
 		So(results[1], shouldBeAppend)
 		So(results[0].list, ShouldHaveLength, 1)
 		So(results[1].list, ShouldHaveLength, 1)

--- a/op_sort.go
+++ b/op_sort.go
@@ -111,7 +111,7 @@ func sortList(path string, list []interface{}, key string) error {
 		switch kind {
 		case reflect.Map.String():
 			if key == "" {
-				key = "name"
+				key = getDefaultIdentifierKey()
 			}
 
 			if err := canKeyMergeArray("list", list, path, key); err != nil {


### PR DESCRIPTION
Fix issue #267 by harmonizing the way Spruce processes list modifications. Due to historic reasons, `inline`, `replace` and (default) `merge` had a different path through the `mergeArray` routine of Spruce. Operators like `insert` or `delete` introduced a general purpose type to encapsulate the details about their intended modifications. In order to fix the issue, I saw no other way than to unify these two ways into one common style.

Since this covers quite some functions of Spruce, I decided to separate the required changes into different commits:
- One commit to add the test cases,
- one commit to fix the issue,
- and three commits to clean-up the code.

In theory, the last three commits could be removed from the PR.

