### PR TITLE
Update documentation with dot issue

### DIFF
--- a/doc/operators.md
+++ b/doc/operators.md
@@ -32,6 +32,15 @@ see the [array merging documentation][array-merging]:
 - `(( delete ))` - Deletes data at a specific index, or objects identified by the value
   of a specified key.
 
+*Please note:* You cannot use the convenient Spruce path syntax
+(`path.to.your.property`) in case one of the elements (e.g. named entry
+element) contains a dot as part of the actual key. The dot is in line with the
+YAML syntax, however it cannot be used since Spruce uses it as a separator
+internally. This also applies to operators, where it is not immediately obvious
+that a path is used like with the `(( prune ))` operator. As a workaround,
+depending on the actual use-case, it is often possible to replace the Spruce
+operator with a equivalent [go-patch] operator file.
+
 ## Operator Arguments
 
 Most `spruce` operators have arguments. There are three basic types to the arguments -
@@ -247,7 +256,10 @@ Usage: `(( prune ))`
 
 If you have a need to force the cleanup of data from the final output, but don't want
 to rely on the end-user always specifying the necessary `--prune` flags, you can
-make use `(( prune ))`s to clear out the bloated data..
+make use `(( prune ))`s to clear out the bloated data. _Please note:_ Both the CLI
+flag as well as the operator will not work if one path element contains a dot as the
+actual name, e.g. `10.local: (( prune ))` will **not** work. You have to use the
+go-patch equivalent instruction instead.
 
 [Example][prune-example]
 
@@ -315,6 +327,7 @@ look up Vault paths.
 [array-merging]: https://github.com/geofffranks/spruce/blob/master/doc/array-merging.md
 [env-var]:       https://github.com/geofffranks/spruce/blob/master/doc/environment-variables-and-defaults.md
 [vault]:         https://vaultproject.io
+[go-patch]:      https://github.com/cppforlife/go-patch
 
 [calc-example]:       http://play.spruce.cf/#537ceec949163403ff42fc52331d2c26
 [cartesian-example]:  http://play.spruce.cf/#a1bb0cde87c2787b0a46603f3263a70d


### PR DESCRIPTION
Add sections to the operator documentation to explain why in certain use-cases
a dot in the path element name is a problem for operators like `(( prune ))`
or `(( grab ... ))`.

This is in response to #271 