### PR TITLE
Add Dockerfile to create base layer image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:alpine as build
+RUN apk --no-cache add git
+COPY . /go/src/github.com/geofffranks/spruce
+RUN cd /go/src/github.com/geofffranks/spruce && \
+    CGOENABLED=0 go build \
+       -o /usr/bin/spruce \
+       -tags netgo \
+       -ldflags "-s -w -extldflags '-static' -X main.Version=$( (git describe --tags 2>/dev/null || (git rev-parse HEAD | cut -c-8)) | sed 's/^v//' )" \
+       cmd/spruce/main.go
+
+FROM scratch
+COPY --from=build /usr/bin/spruce /spruce
+ENV PATH=/
+CMD ["/spruce"]


### PR DESCRIPTION
I read the issue regarding the Dockerfile for Spruce. Although I never really ran into the use case with Spruce, we used something similar in [another project](https://github.com/homeport/havener). The other part of the puzzle are the Docker Hub automatic builds, which help to create the Docker images. Please note, this Dockerfile comes with the idea of creating the binary from scratch based on the current working directory. For Concourse and its Docker related resources, it would need to be written differently I think. This would address part of the issue #281.

The Docker Hub Build settings would need to look like this:
<img width="1052" alt="image" src="https://user-images.githubusercontent.com/1979133/52565154-50b17780-2e06-11e9-9e4c-b92ca8e04bc3.png">

```sh
$ docker run -it --rm heavywombat/spruce:1.19.42 spruce --version
Unable to find image 'heavywombat/spruce:1.19.42' locally
1.19.42: Pulling from heavywombat/spruce
6a27eeff4259: Pull complete
Digest: sha256:30b0bf4db871dfacbe4f6150d637fa0258d6553cc2d288f844f1a55301190b04
Status: Downloaded newer image for heavywombat/spruce:1.19.42
spruce - Version 1.19.42
```