### PR TITLE
Better v1 / v2 handling for vault operator

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -82,6 +82,10 @@
 		{
 			"ImportPath": "gopkg.in/yaml.v2",
 			"Rev": "49c95bdc21843256fb6c4e0d370a05f24a0bf213"
+		},
+		{
+			"ImportPath": "github.com/cloudfoundry-community/vaultkv",
+			"Rev": "0ed39daafa01eaa5f526c6bc2581e80896e9674f"
 		}
 	]
 }

--- a/op_vault.go
+++ b/op_vault.go
@@ -1,17 +1,16 @@
 package spruce
 
 import (
-	"bytes"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
-	"strconv"
 	"strings"
 
+	"github.com/cloudfoundry-community/vaultkv"
 	"github.com/starkandwayne/goutils/ansi"
 
 	. "github.com/geofffranks/spruce/log"
@@ -21,6 +20,8 @@ import (
 	// Also https://github.com/go-yaml/yaml/pull/195
 	"github.com/geofffranks/yaml"
 )
+
+var kv *vaultkv.KV = nil
 
 var vaultSecretCache = map[string]map[string]interface{}{}
 
@@ -35,47 +36,6 @@ var SkipVault bool
 // other secrets from a Vault (vaultproject.io) Secure Key Storage
 // instance.
 type VaultOperator struct{}
-
-// The VaultResponse provides a common parsing method for responses
-// from any Vault API
-type VaultResponse interface {
-	Parse(b []byte) (*VaultCommonResponse, error)
-}
-
-type VaultCommonResponse struct {
-	Data   map[string]interface{}
-	Errors []string
-}
-
-type VaultV1Response struct {
-	VaultCommonResponse
-}
-
-type VaultV2Response struct {
-	VaultCommonResponse
-	Data struct {
-		Data map[string]interface{}
-	}
-	Metadata struct {
-		Version int
-	}
-}
-
-func (r VaultV1Response) Parse(b []byte) (*VaultCommonResponse, error) {
-	err := json.NewDecoder(bytes.NewReader(b)).Decode(&r)
-	if err != nil {
-		return nil, err
-	}
-	return &VaultCommonResponse{Data: r.Data, Errors: r.Errors}, nil
-}
-
-func (r VaultV2Response) Parse(b []byte) (*VaultCommonResponse, error) {
-	err := json.NewDecoder(bytes.NewReader(b)).Decode(&r)
-	if err != nil {
-		return nil, err
-	}
-	return &VaultCommonResponse{Data: r.Data.Data, Errors: r.Errors}, nil
-}
 
 // Setup ...
 func (VaultOperator) Setup() error {
@@ -93,6 +53,83 @@ func (VaultOperator) Phase() OperatorPhase {
 // command.
 func (VaultOperator) Dependencies(_ *Evaluator, _ []*Expr, _ []*tree.Cursor, auto []*tree.Cursor) []*tree.Cursor {
 	return auto
+}
+
+func initializeVaultClient() error {
+	addr := os.Getenv("VAULT_ADDR")
+	token := os.Getenv("VAULT_TOKEN")
+	skip := false
+
+	if addr == "" || token == "" {
+		svtoken := struct {
+			Vault      string `yaml:"vault"`
+			Token      string `yaml:"token"`
+			SkipVerify bool   `yaml:"skip_verify"`
+		}{}
+		b, err := ioutil.ReadFile(os.ExpandEnv("${HOME}/.svtoken"))
+		if err == nil {
+			err = yaml.Unmarshal(b, &svtoken)
+			if err == nil {
+				addr = svtoken.Vault
+				token = svtoken.Token
+				skip = svtoken.SkipVerify
+			}
+		}
+	}
+
+	if skipVaultVerify(os.Getenv("VAULT_SKIP_VERIFY")) {
+		skip = true
+	}
+
+	if token == "" {
+		b, err := ioutil.ReadFile(fmt.Sprintf("%s/.vault-token", os.Getenv("HOME")))
+		if err == nil {
+			token = strings.TrimSuffix(string(b), "\n")
+		}
+	}
+
+	if addr == "" || token == "" {
+		return fmt.Errorf("Failed to determine Vault URL / token, and the $REDACT environment variable is not set.")
+	}
+
+	roots, err := x509.SystemCertPool()
+	if err != nil {
+		return fmt.Errorf("unable to retrieve system root certificate authorities: %s", err)
+	}
+
+	parsedURL, err := url.Parse(addr)
+	if err != nil {
+		return fmt.Errorf("Could not parse Vault URL `%s': %s", addr, err)
+	}
+
+	client := &vaultkv.Client{
+		AuthToken: token,
+		VaultURL:  parsedURL,
+		Client: &http.Client{
+			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
+				TLSClientConfig: &tls.Config{
+					RootCAs:            roots,
+					InsecureSkipVerify: skip,
+				},
+			},
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				if len(via) > 10 {
+					return fmt.Errorf("stopped after 10 redirects")
+				}
+				req.Header.Add("X-Vault-Token", token)
+				return nil
+			},
+		},
+	}
+
+	if err != nil {
+		return fmt.Errorf("Error setting up Vault client: %s", err)
+	}
+
+	kv = client.NewKV()
+
+	return nil
 }
 
 // Run executes the `(( vault ... ))` operator call, which entails
@@ -171,59 +208,14 @@ func (VaultOperator) Run(ev *Evaluator, args []*Expr) (*Response, error) {
 		     3. ~/.vault-token file, if it exists
 		*/
 
-		url := os.Getenv("VAULT_ADDR")
-		token := os.Getenv("VAULT_TOKEN")
-		skip := false
-		version := os.Getenv("VAULT_VERSION")
-
-		if url == "" || token == "" {
-			svtoken := struct {
-				Vault      string `yaml:"vault"`
-				Token      string `yaml:"token"`
-				SkipVerify bool   `yaml:"skip_verify"`
-				Version    string `yaml:"api_version"`
-			}{}
-			b, err := ioutil.ReadFile(os.ExpandEnv("${HOME}/.svtoken"))
-			if err == nil {
-				err = yaml.Unmarshal(b, &svtoken)
-				if err == nil {
-					url = svtoken.Vault
-					token = svtoken.Token
-					skip = svtoken.SkipVerify
-					version = svtoken.Version
-				}
+		if kv == nil {
+			err := initializeVaultClient()
+			if err != nil {
+				return nil, fmt.Errorf("Error during Vault client initialization: %s", err)
 			}
 		}
 
-		if skipVaultVerify(os.Getenv("VAULT_SKIP_VERIFY")) {
-			skip = true
-		}
-
-		if version == "" {
-			version = "1"
-		}
-
-		if token == "" {
-			b, err := ioutil.ReadFile(fmt.Sprintf("%s/.vault-token", os.Getenv("HOME")))
-			if err == nil {
-				token = strings.TrimSuffix(string(b), "\n")
-			}
-		}
-
-		if url == "" || token == "" {
-			return nil, fmt.Errorf("Failed to determine Vault URL / token, and the $REDACT environment variable is not set.")
-		}
-
-		os.Setenv("VAULT_ADDR", url)
-		os.Setenv("VAULT_TOKEN", token)
-		if skip {
-			os.Setenv("VAULT_SKIP_VERIFY", "1")
-		} else {
-			os.Unsetenv("VAULT_SKIP_VERIFY")
-		}
-		os.Setenv("VAULT_VERSION", version)
-
-		engine, leftPart, rightPart, versionPart := parsePath(key)
+		leftPart, rightPart := parsePath(key)
 		if leftPart == "" || rightPart == "" {
 			return nil, ansi.Errorf("@R{invalid argument} @c{%s}@R{; must be in the form} @m{path/to/secret:key}", key)
 		}
@@ -234,14 +226,20 @@ func (VaultOperator) Run(ev *Evaluator, args []*Expr) (*Response, error) {
 		} else {
 			DEBUG("vault: Cache MISS for `%s`", leftPart)
 			// Secret isn't cached. Grab it from the vault.
-			fullSecret, err = getVaultSecret(engine, leftPart, versionPart)
+			fullSecret, err = getVaultSecret(leftPart)
 			if err != nil {
+				//Normalize the error messages
+				switch err.(type) {
+				case *vaultkv.ErrNotFound:
+					err = fmt.Errorf("secret %s not found", key)
+				}
+
 				return nil, err
 			}
 			vaultSecretCache[leftPart] = fullSecret
 		}
 
-		secret, err = extractSubkey(fullSecret, engine, leftPart, rightPart)
+		secret, err = extractSubkey(fullSecret, leftPart, rightPart)
 		if err != nil {
 			return nil, err
 		}
@@ -259,104 +257,24 @@ func init() {
 
 /****** VAULT INTEGRATION ***********************************/
 
-func getVaultSecret(engine string, secret string, version int) (map[string]interface{}, error) {
-	vault := os.Getenv("VAULT_ADDR")
-	apiVersion, err := getIntEnvVar("VAULT_VERSION")
+func getVaultSecret(secret string) (map[string]interface{}, error) {
+	ret := map[string]interface{}{}
+
+	DEBUG("Fetching Vault secret at `%s'", secret)
+	_, err := kv.Get(secret, &ret, nil)
 	if err != nil {
+		DEBUG(" failure.")
 		return nil, err
 	}
-	skip := os.Getenv("VAULT_SKIP_VERIFY")
-	DEBUG("  accessing the vault api v%d at %s (with VAULT_SKIP_VERIFY='%s')", apiVersion, vault, skip)
-
-	var url string
-	var raw VaultResponse
-
-	if apiVersion == 1 {
-		url = fmt.Sprintf("%s/v1/%s/%s", vault, engine, secret)
-		raw = VaultV1Response{}
-	} else if apiVersion == 2 {
-		url = fmt.Sprintf("%s/v1/%s/data/%s?version=%d", vault, engine, secret, version)
-		raw = VaultV2Response{}
-	} else {
-		return nil, fmt.Errorf("invalid Vault API version: v%d", apiVersion)
-	}
-
-	DEBUG("  crafting GET %s", url)
-
-	roots, err := x509.SystemCertPool()
-	if err != nil {
-		return nil, fmt.Errorf("unable to retrieve system root certificate authorities: %s", err)
-	}
-
-	client := &http.Client{
-		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			TLSClientConfig: &tls.Config{
-				RootCAs:            roots,
-				InsecureSkipVerify: skipVaultVerify(os.Getenv("VAULT_SKIP_VERIFY")),
-			},
-		},
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if len(via) > 10 {
-				return fmt.Errorf("stopped after 10 redirects")
-			}
-			req.Header.Add("X-Vault-Token", os.Getenv("VAULT_TOKEN"))
-			return nil
-		},
-	}
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		DEBUG("    !! failed to craft API request:\n    !! %s\n", err)
-		return nil, ansi.Errorf("@R{failed to retrieve} @c{%s}@R{ from Vault (%s): %s}",
-			secret, vault, err)
-	}
-	req.Header.Add("X-Vault-Token", os.Getenv("VAULT_TOKEN"))
-
-	DEBUG("  issuing GET %s", url)
-	res, err := client.Do(req)
-	if err != nil {
-		DEBUG("    !! failed to issue API request:\n    !! %s\n", err)
-		return nil, ansi.Errorf("@R{failed to retrieve} @c{%s} @R{from Vault (%s): %s}",
-			secret, vault, err)
-	}
-	defer res.Body.Close()
-
-	TRACE("    reading response body")
-	b, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		DEBUG("    !! failed to read JSON:\n    !! %s\n", err)
-		return nil, ansi.Errorf("@R{failed to retrieve} @c{%s} @R{from Vault (%s): %s}",
-			secret, vault, err)
-	}
-
-	TRACE("    decoding raw JSON:\n%s\n", string(b))
-	var response *VaultCommonResponse
-	response, err = raw.Parse(b)
-
-	if err != nil {
-		DEBUG("    !! failed to decode JSON:\n    !! %s\n", err)
-		return nil, fmt.Errorf("bad JSON response received from Vault: \"%s\"", string(b))
-	}
-
-	if len(response.Errors) > 0 {
-		DEBUG("    !! error: %s", response.Errors[0])
-		return nil, ansi.Errorf("@R{failed to retrieve} @c{%s} @R{from Vault (%s): %s}",
-			secret, vault, response.Errors[0])
-	}
-
-	// return raw.Data, nil
-	// if err != nil {
-	// 	return nil, err
-	// }
 
 	DEBUG("  success.")
-	return response.Data, nil
+	return ret, nil
 }
 
-func extractSubkey(secretMap map[string]interface{}, engine, secret, subkey string) (string, error) {
+func extractSubkey(secretMap map[string]interface{}, secret, subkey string) (string, error) {
 	DEBUG("  extracting the [%s] subkey from the secret", subkey)
 
-	secretSubkeyPath := fmt.Sprintf("%s/%s:%s", engine, secret, subkey)
+	secretSubkeyPath := fmt.Sprintf("%s:%s", secret, subkey)
 	v, ok := secretMap[subkey]
 	if !ok {
 		DEBUG("    !! %s not found!\n", secretSubkeyPath)
@@ -370,13 +288,8 @@ func extractSubkey(secretMap map[string]interface{}, engine, secret, subkey stri
 	return v.(string), nil
 }
 
-func parsePath(path string) (engine, secret, key string, version int) {
-	if idx := strings.Index(path, "/"); idx >= 0 {
-		engine = path[:idx]
-		path = path[idx+1:]
-	}
+func parsePath(path string) (secret, key string) {
 	secret = path
-	version = 0
 	if idx := strings.LastIndex(path, ":"); idx >= 0 {
 		secret = path[:idx]
 		key = path[idx+1:]
@@ -390,16 +303,4 @@ func skipVaultVerify(env string) bool {
 		return false
 	}
 	return true
-}
-
-func getIntEnvVar(key string) (int, error) {
-	s := os.Getenv(key)
-	if s == "" {
-		return 0, fmt.Errorf("environment variable %s is empty", key)
-	}
-	v, err := strconv.Atoi(s)
-	if err != nil {
-		return 0, err
-	}
-	return v, nil
 }

--- a/op_vault.go
+++ b/op_vault.go
@@ -102,6 +102,14 @@ func initializeVaultClient() error {
 		return fmt.Errorf("Could not parse Vault URL `%s': %s", addr, err)
 	}
 
+	if parsedURL.Port() == "" {
+		if parsedURL.Scheme == "http" {
+			parsedURL.Host = parsedURL.Host + ":80"
+		} else {
+			parsedURL.Host = parsedURL.Host + ":443"
+		}
+	}
+
 	client := &vaultkv.Client{
 		AuthToken: token,
 		VaultURL:  parsedURL,

--- a/vault_test.go
+++ b/vault_test.go
@@ -38,6 +38,9 @@ func TestVault(t *testing.T) {
 		return ToYAML(YAML(s))
 	}
 	RunTests := func(src string) {
+		//Act like we're running Spruce freshly
+		kv = nil
+
 		var test, input, output string
 		var current *string
 		testPat := regexp.MustCompile(`^##+\s+(.*)\s*$`)
@@ -135,267 +138,90 @@ secret: REDACTED
 `)
 	})
 
-	Convey("Connected Vault Api v1", t, func() {
-		mock := httptest.NewServer(
-			http.HandlerFunc(
-				func(w http.ResponseWriter, r *http.Request) {
-					if r.Header.Get("X-Vault-Token") != "sekrit-toekin" {
-						w.WriteHeader(403)
-						fmt.Fprintf(w, `{"errors":["missing client token"]}`)
-						return
-					}
-					switch r.URL.Path {
-					case "/v1/secret/hand":
-						w.WriteHeader(200)
-						fmt.Fprintf(w, `{"data":{"shake":"knock, knock"}}`)
-					case "/v1/secret/admin":
-						w.WriteHeader(200)
-						fmt.Fprintf(w, `{"data":{"username":"admin","password":"x12345"}}`)
-					case "/v1/secret/key":
-						w.WriteHeader(200)
-						fmt.Fprintf(w, `{"data":{"test":"testing"}}`)
-					case "/v1/secret/malformed":
-						w.WriteHeader(200)
-						fmt.Fprintf(w, `wait, this isn't JSON`)
-					case "/v1/secret/structure":
-						w.WriteHeader(200)
-						fmt.Fprintf(w, `{"data":{"data":[1,2,3]}}`)
-					default:
-						w.WriteHeader(404)
-						fmt.Fprintf(w, `{"errors":[]}`)
-					}
-				},
-			),
-		)
-		defer mock.Close()
+	allTestVault := func(version int) {
+		mock := &httptest.Server{}
 
-		SkipVault = false
-		os.Setenv("VAULT_ADDR", mock.URL)
-		os.Setenv("VAULT_TOKEN", "sekrit-toekin")
-		RunTests(`
-################################################  emits sensitive credentials
----
-meta:
-  prefix: secret
-  key: secret/key:test
-secret: (( vault "secret/hand:shake" ))
-username: (( vault "secret/admin:username" ))
-password: (( vault "secret/admin:password" ))
-prefixed: (( vault meta.prefix "/admin:password" ))
-key: (( vault $.meta.key ))
+		mountsResp := fmt.Sprintf(`{"request_id":"592b4162-c855-7987-e6aa-8ef3d9d1393e","lease_id":"","renewable":false,"lease_duration":0,"data":{"auth":{"token/":{"accessor":"auth_token_87436efa","config":{"default_lease_ttl":0,"force_no_cache":false,"max_lease_ttl":0,"token_type":"default-service"},"description":"token based credentials","local":false,"options":null,"seal_wrap":false,"type":"token"}},"secret":{"cubbyhole/":{"accessor":"cubbyhole_304cf103","config":{"default_lease_ttl":0,"force_no_cache":false,"max_lease_ttl":0},"description":"per-token private secret storage","local":true,"options":null,"seal_wrap":false,"type":"cubbyhole"},"identity/":{"accessor":"identity_68585106","config":{"default_lease_ttl":0,"force_no_cache":false,"max_lease_ttl":0},"description":"identity store","local":false,"options":null,"seal_wrap":false,"type":"identity"},"secret/":{"accessor":"kv_c707ea61","config":{"default_lease_ttl":0,"force_no_cache":false,"max_lease_ttl":0},"description":"key/value secret storage","local":false,"options":{"version":"%d"},"seal_wrap":false,"type":"kv"},"sys/":{"accessor":"system_1ef88192","config":{"default_lease_ttl":0,"force_no_cache":false,"max_lease_ttl":0},"description":"system endpoints used for control, policy and debugging","local":false,"options":null,"seal_wrap":false,"type":"system"}}},"wrap_info":null,"warnings":null,"auth":null}`, version)
 
----
-meta:
-  key: secret/key:test
-  prefix: secret
-secret: knock, knock
-username: admin
-password: x12345
-prefixed: x12345
-key: testing
-`)
+		switch version {
+		case 1:
+			mock = httptest.NewServer(
+				http.HandlerFunc(
+					func(w http.ResponseWriter, r *http.Request) {
+						if r.Header.Get("X-Vault-Token") != "sekrit-toekin" {
+							w.WriteHeader(403)
+							fmt.Fprintf(w, `{"errors":["missing client token"]}`)
+							return
+						}
+						switch r.URL.Path {
+						case "/v1/sys/internal/ui/mounts":
+							w.WriteHeader(200)
+							fmt.Fprintf(w, mountsResp)
+						case "/v1/secret/hand":
+							w.WriteHeader(200)
+							fmt.Fprintf(w, `{"data":{"shake":"knock, knock"}}`)
+						case "/v1/secret/admin":
+							w.WriteHeader(200)
+							fmt.Fprintf(w, `{"data":{"username":"admin","password":"x12345"}}`)
+						case "/v1/secret/key":
+							w.WriteHeader(200)
+							fmt.Fprintf(w, `{"data":{"test":"testing"}}`)
+						case "/v1/secret/malformed":
+							w.WriteHeader(200)
+							fmt.Fprintf(w, `wait, this isn't JSON`)
+						case "/v1/secret/structure":
+							w.WriteHeader(200)
+							fmt.Fprintf(w, `{"data":{"data":[1,2,3]}}`)
+						default:
+							w.WriteHeader(404)
+							fmt.Fprintf(w, `{"errors":[]}`)
+						}
+					},
+				),
+			)
 
-		os.Setenv("VAULT_ADDR", mock.URL)
-		oldhome := os.Getenv("HOME")
-		os.Setenv("HOME", "assets/home/auth")
-		os.Setenv("VAULT_TOKEN", "")
-		RunTests(`
-##########################  retrieves token transparently from ~/.vault-token
----
-secret: (( vault "secret/hand:shake" ))
+		case 2:
+			mock = httptest.NewServer(
+				http.HandlerFunc(
+					func(w http.ResponseWriter, r *http.Request) {
+						if r.Header.Get("X-Vault-Token") != "sekrit-toekin" {
+							w.WriteHeader(403)
+							fmt.Fprintf(w, `{"errors":["missing client token"]}`)
+							return
+						}
+						switch r.URL.Path {
+						case "/v1/sys/internal/ui/mounts":
+							w.WriteHeader(200)
+							fmt.Fprintf(w, mountsResp)
+						case "/v1/secret/data/hand":
+							w.WriteHeader(200)
+							fmt.Fprintf(w, `{"data":{"data:{"shake":"knock, knock"}}`)
+						case "/v1/secret/data/admin":
+							w.WriteHeader(200)
+							fmt.Fprintf(w, `{"data":{"data:{"username":"admin","password":"x12345"}}`)
+						case "/v1/secret/data/key":
+							w.WriteHeader(200)
+							fmt.Fprintf(w, `{"data":{"data:{"test":"testing"}}`)
+						case "/v1/secret/data/malformed":
+							w.WriteHeader(200)
+							fmt.Fprintf(w, `wait, this isn't JSON`)
+						case "/v1/secret/data/structure":
+							w.WriteHeader(200)
+							fmt.Fprintf(w, `{"data":{"data:{"data":[1,2,3]}}`)
+						default:
+							w.WriteHeader(404)
+							fmt.Fprintf(w, `{"errors":[]}`)
+						}
+					},
+				),
+			)
 
----
-secret: knock, knock
-`)
-
-		os.Setenv("VAULT_ADDR", "garbage")
-		os.Setenv("VAULT_TOKEN", "")
-		os.Setenv("HOME", "assets/home/svtoken")
-		ioutil.WriteFile("assets/home/svtoken/.svtoken",
-			[]byte("vault: "+mock.URL+"\n"+
-				"token: sekrit-toekin\n"), 0644)
-		RunTests(`
-##############################  retrieves token transparently from ~/.svtoken
----
-secret: (( vault "secret/hand:shake" ))
-
----
-secret: knock, knock
-`)
-
-		/* RESET TO A VALID, AUTHENTICATED STATE */
-		os.Setenv("VAULT_ADDR", mock.URL)
-		os.Setenv("HOME", "assets/home/auth")
-
-		RunErrorTests(`
-#########################################  fails when missing its argument
----
-secret: (( vault ))
-
----
-1 error(s) detected:
- - $.secret: vault operator requires at least one argument
-
-#########################################  fails on non-existent reference
----
-meta: {}
-secret: (( vault $.meta.key ))
-
----
-1 error(s) detected:
- - $.secret: Unable to resolve ` + "`" + `meta.key` + "`" + `: ` + "`" + `$.meta.key` + "`" + ` could not be found in the datastructure
-
-####################################################  fails on map reference
----
-meta:
-  key: secret/hand2:shake
-secret: (( vault $.meta ))
-
----
-1 error(s) detected:
- - $.secret: tried to look up $.meta, which is not a string scalar
-
-##################################################  fails on list reference
----
-meta:
-  - first
-secret: (( vault $.meta ))
-
----
-1 error(s) detected:
- - $.secret: tried to look up $.meta, which is not a string scalar
-
-#########################################  fails on non-existent credentials
----
-secret: (( vault "secret/e:noent" ))
-
----
-1 error(s) detected:
- - $.secret: secret secret/e:noent not found
-
-##############################################  fails on non-string argument
----
-secret: (( vault 42 ))
-
----
-1 error(s) detected:
- - $.secret: invalid argument 42; must be in the form path/to/secret:key
-
-#################################################  fails on non-JSON response
----
-secret: (( vault "secret/malformed:key" ))
-
----
-1 error(s) detected:
- - $.secret: bad JSON response received from Vault: "wait, this isn't JSON"
-
-#################################################  fails on non-string data
----
-secret: (( vault "secret/structure:data" ))
-
----
-1 error(s) detected:
- - $.secret: secret secret/structure:data is not a string
-
-`)
-
-		os.Setenv("VAULT_TOKEN", "incorrect")
-		RunErrorTests(`
-#####################################################  fails on a bad token
----
-secret: (( vault "hand3:shake" ))
-
----
-1 error(s) detected:
- - $.secret: failed to retrieve hand3 from Vault (` + os.Getenv("VAULT_ADDR") + `): missing client token
-
-`)
-
-		oldhome = os.Getenv("HOME")
-		os.Setenv("HOME", "assets/home/unauth")
-		SkipVault = false
-		os.Setenv("VAULT_TOKEN", "")
-		RunErrorTests(`
-################################################  fails on a missing token
----
-secret: (( vault "secret/hand4:shake" ))
-
----
-1 error(s) detected:
- - $.secret: Failed to determine Vault URL / token, and the $REDACT environment variable is not set.
-
-`)
-		os.Setenv("HOME", oldhome)
-	})
-
-	Convey("It correctly parses path", t, func() {
-		for _, test := range []struct {
-			path      string //The full path to run through the parse function
-			expEngine string
-			expSecret string //What is expected to be left of the colon
-			expKey    string //What is expected to be right of the colon
-		}{
-			//-----TEST CASES GO HERE-----
-			// { "path to parse", "expected secret", "expected key" }
-			{"just/a/secret", "just", "a/secret", ""},
-			{"secret/with/colon:", "secret", "with/colon", ""},
-			{":", "", "", ""},
-			{"a:", "", "a", ""},
-			{"", "", "", ""},
-			{"secret/and:key", "secret", "and", "key"},
-			{":justakey", "", "", "justakey"},
-			{"secretwithcolon://127.0.0.1:", "secretwithcolon:", "/127.0.0.1", ""},
-			{"secretwithcolons://127.0.0.1:8500:", "secretwithcolons:", "/127.0.0.1:8500", ""},
-			{"secretwithcolons://127.0.0.1:8500:andkey", "secretwithcolons:", "/127.0.0.1:8500", "andkey"},
-		} {
-			Convey(test.path, func() {
-				engine, secret, key, version := parsePath(test.path)
-				So(engine, ShouldEqual, test.expEngine)
-				So(secret, ShouldEqual, test.expSecret)
-				So(key, ShouldEqual, test.expKey)
-				So(version, ShouldEqual, 0)
-			})
 		}
-	})
-
-	Convey("Connected Vault Api v2", t, func() {
-		mock := httptest.NewServer(
-			http.HandlerFunc(
-				func(w http.ResponseWriter, r *http.Request) {
-					if r.Header.Get("X-Vault-Token") != "sekrit-toekin" {
-						w.WriteHeader(403)
-						fmt.Fprintf(w, `{"errors":["missing client token"]}`)
-						return
-					}
-					switch r.URL.Path {
-					case "/v1/secret/data/hand":
-						w.WriteHeader(200)
-						fmt.Fprintf(w, `{"data":{"data:{"shake":"knock, knock"}}`)
-					case "/v1/secret/data/admin":
-						w.WriteHeader(200)
-						fmt.Fprintf(w, `{"data":{"data:{"username":"admin","password":"x12345"}}`)
-					case "/v1/secret/data/key":
-						w.WriteHeader(200)
-						fmt.Fprintf(w, `{"data":{"data:{"test":"testing"}}`)
-					case "/v1/secret/data/malformed":
-						w.WriteHeader(200)
-						fmt.Fprintf(w, `wait, this isn't JSON`)
-					case "/v1/secret/data/structure":
-						w.WriteHeader(200)
-						fmt.Fprintf(w, `{"data":{"data:{"data":[1,2,3]}}`)
-					default:
-						w.WriteHeader(404)
-						fmt.Fprintf(w, `{"errors":[]}`)
-					}
-				},
-			),
-		)
 		defer mock.Close()
 
 		SkipVault = false
 		os.Setenv("VAULT_ADDR", mock.URL)
 		os.Setenv("VAULT_TOKEN", "sekrit-toekin")
-		os.Setenv("VAULT_VERSION", "2")
 		RunTests(`
 ################################################  emits sensitive credentials
 ---
@@ -423,7 +249,6 @@ key: testing
 		oldhome := os.Getenv("HOME")
 		os.Setenv("HOME", "assets/home/auth")
 		os.Setenv("VAULT_TOKEN", "")
-		os.Setenv("VAULT_VERSION", "2")
 		RunTests(`
 ##########################  retrieves token transparently from ~/.vault-token
 ---
@@ -435,7 +260,6 @@ secret: knock, knock
 
 		os.Setenv("VAULT_ADDR", "garbage")
 		os.Setenv("VAULT_TOKEN", "")
-		os.Setenv("VAULT_VERSION", "2")
 		os.Setenv("HOME", "assets/home/svtoken")
 		ioutil.WriteFile("assets/home/svtoken/.svtoken",
 			[]byte("vault: "+mock.URL+"\n"+
@@ -507,14 +331,6 @@ secret: (( vault 42 ))
 1 error(s) detected:
  - $.secret: invalid argument 42; must be in the form path/to/secret:key
 
-#################################################  fails on non-JSON response
----
-secret: (( vault "secret/malformed:key" ))
-
----
-1 error(s) detected:
- - $.secret: bad JSON response received from Vault: "wait, this isn't JSON"
-
 #################################################  fails on non-string data
 ---
 secret: (( vault "secret/structure:data" ))
@@ -533,7 +349,7 @@ secret: (( vault "hand3:shake" ))
 
 ---
 1 error(s) detected:
- - $.secret: failed to retrieve hand3 from Vault (` + os.Getenv("VAULT_ADDR") + `): missing client token
+ - $.secret: missing client token
 
 `)
 
@@ -541,7 +357,6 @@ secret: (( vault "hand3:shake" ))
 		os.Setenv("HOME", "assets/home/unauth")
 		SkipVault = false
 		os.Setenv("VAULT_TOKEN", "")
-		os.Setenv("VAULT_VERSION", "2")
 		RunErrorTests(`
 ################################################  fails on a missing token
 ---
@@ -549,39 +364,45 @@ secret: (( vault "secret/hand4:shake" ))
 
 ---
 1 error(s) detected:
- - $.secret: Failed to determine Vault URL / token, and the $REDACT environment variable is not set.
+ - $.secret: Error during Vault client initialization: Failed to determine Vault URL / token, and the $REDACT environment variable is not set.
 
 `)
 		os.Setenv("HOME", oldhome)
+	}
+
+	Convey("Testing Vault", t, func() {
+		Convey("With KV v1", func() {
+			allTestVault(1)
+		})
+
+		Convey("With KV v2", func() {
+			allTestVault(2)
+		})
 	})
 
 	Convey("It correctly parses path", t, func() {
 		for _, test := range []struct {
 			path      string //The full path to run through the parse function
-			expEngine string
 			expSecret string //What is expected to be left of the colon
 			expKey    string //What is expected to be right of the colon
-			// expVersion int
 		}{
 			//-----TEST CASES GO HERE-----
 			// { "path to parse", "expected secret", "expected key" }
-			{"just/a/secret", "just", "a/secret", ""},
-			{"secret/with/colon:", "secret", "with/colon", ""},
-			{":", "", "", ""},
-			{"a:", "", "a", ""},
-			{"", "", "", ""},
-			{"secret/and:key", "secret", "and", "key"},
-			{":justakey", "", "", "justakey"},
-			{"secretwithcolon://127.0.0.1:", "secretwithcolon:", "/127.0.0.1", ""},
-			{"secretwithcolons://127.0.0.1:8500:", "secretwithcolons:", "/127.0.0.1:8500", ""},
-			{"secretwithcolons://127.0.0.1:8500:andkey", "secretwithcolons:", "/127.0.0.1:8500", "andkey"},
+			{"just/a/secret", "just/a/secret", ""},
+			{"secret/with/colon:", "secret/with/colon", ""},
+			{":", "", ""},
+			{"a:", "a", ""},
+			{"", "", ""},
+			{"secret/and:key", "secret/and", "key"},
+			{":justakey", "", "justakey"},
+			{"secretwithcolon://127.0.0.1:", "secretwithcolon://127.0.0.1", ""},
+			{"secretwithcolons://127.0.0.1:8500:", "secretwithcolons://127.0.0.1:8500", ""},
+			{"secretwithcolons://127.0.0.1:8500:andkey", "secretwithcolons://127.0.0.1:8500", "andkey"},
 		} {
 			Convey(test.path, func() {
-				engine, secret, key, version := parsePath(test.path)
-				So(engine, ShouldEqual, test.expEngine)
+				secret, key := parsePath(test.path)
 				So(secret, ShouldEqual, test.expSecret)
 				So(key, ShouldEqual, test.expKey)
-				So(version, ShouldEqual, 0)
 			})
 		}
 	})

--- a/vendor/github.com/cloudfoundry-community/vaultkv/.gitignore
+++ b/vendor/github.com/cloudfoundry-community/vaultkv/.gitignore
@@ -1,0 +1,1 @@
+*.coverprofile

--- a/vendor/github.com/cloudfoundry-community/vaultkv/LICENSE
+++ b/vendor/github.com/cloudfoundry-community/vaultkv/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org>

--- a/vendor/github.com/cloudfoundry-community/vaultkv/README.md
+++ b/vendor/github.com/cloudfoundry-community/vaultkv/README.md
@@ -1,0 +1,46 @@
+# vaultkv
+
+## How to Use
+
+This is a GoDoc: https://godoc.org/github.com/cloudfoundry-community/vaultkv
+
+If you want to do anything with this library, then you'll need to make a
+Client object. The Client object will need, at the very least, its `VaultURI`
+member populated. AuthToken should be set to your bearer token for Vault. If
+you need a bearer token created from some other auth method, you can call one
+of the AuthX functions (currently, we support Github, LDAP, and Userpass). An
+http client can be optionally provided (if not, then `http.DefaultClient`
+will be used). If you would like to see information about the requests and
+responses, then you can optionally provide an io.Writer for trace logs to be
+streamed to.
+
+```go
+func main() {
+  vault := &vaultkv.Client{
+  AuthToken: "01234567-89ab-cdef-0123-456789abcdef",
+    VaultURL: vaultURI,
+    Client: &http.Client{
+      Transport: &http.Transport{
+        TLSClientConfig: &tls.Config{
+          InsecureSkipVerify: true,
+        },
+      },
+    },
+    Trace: os.Stdout,
+  }
+
+  output := struct{
+    Bar string `json:"bar"`
+  }{}
+  err := vault.Get("secret/foo", &output)
+  if err != nil {
+    os.Exit(1)
+  }
+
+  fmt.Printf("output.Bar is `%s'\n", output.Bar)
+}
+```
+
+## Testing
+
+Run `./test` in the base directory to test all supported Vault versions. Run `./test latest` to test only the latest supported version of Vault.

--- a/vendor/github.com/cloudfoundry-community/vaultkv/auth.go
+++ b/vendor/github.com/cloudfoundry-community/vaultkv/auth.go
@@ -1,0 +1,114 @@
+package vaultkv
+
+import "fmt"
+
+//AuthOutput is the general structure as returned by AuthX functions. The
+//Metadata member type is determined by the specific Auth function. Note that
+//the Vault must be initialized and unsealed in order to use authentication
+//endpoints.
+type AuthOutput struct {
+	LeaseID       string `json:"lease_id"`
+	Renewable     bool   `json:"renewable"`
+	LeaseDuration int    `json:"lease_duration"`
+	Auth          struct {
+		ClientToken string   `json:"client_token"`
+		Accessor    string   `json:"accessor"`
+		Policies    []string `json:"policies"`
+	}
+	//Metadata's internal structure is dependent on the auth type
+	Metadata interface{} `json:"metadata"`
+}
+
+//AuthGithubMetadata is the metadata member set by AuthGithub.
+type AuthGithubMetadata struct {
+	Username     string `json:"username"`
+	Organization string `json:"org"`
+}
+
+//AuthGithub submits the given accessToken to the github auth endpoint, checking
+// it against configurations for Github organizations. If the accessToken
+// belongs to an authorized account, then the AuthOutput object is returned, and
+// this client's AuthToken is set to the returned token.
+func (v *Client) AuthGithub(accessToken string) (ret *AuthOutput, err error) {
+	ret = &AuthOutput{Metadata: AuthGithubMetadata{}}
+	err = v.doRequest(
+		"POST",
+		"/auth/github/login",
+		struct {
+			Token string `json:"token"`
+		}{Token: accessToken},
+		&ret,
+	)
+
+	if err == nil {
+		v.AuthToken = ret.Auth.ClientToken
+	}
+
+	return
+}
+
+//AuthLDAPMetadata is the metadata member set by AuthLDAP
+type AuthLDAPMetadata struct {
+	Username string `json:"username"`
+}
+
+//AuthLDAP submits the given username and password to the LDAP auth endpoint,
+//checking it against existing LDAP auth configurations. If auth is successful,
+//then the AuthOutput object is returned, and this client's AuthToken is set to
+//the returned token.
+func (v *Client) AuthLDAP(username, password string) (ret *AuthOutput, err error) {
+	ret = &AuthOutput{Metadata: AuthLDAPMetadata{}}
+	err = v.doRequest(
+		"POST",
+		fmt.Sprintf("/auth/ldap/login/%s", username),
+		struct {
+			Password string `json:"password"`
+		}{Password: password},
+		&ret,
+	)
+
+	if err == nil {
+		v.AuthToken = ret.Auth.ClientToken
+	}
+
+	return
+}
+
+//AuthUserpassMetadata is the metadata member set by AuthUserpass
+type AuthUserpassMetadata struct {
+	Username string `json:"username"`
+}
+
+//AuthUserpass submits the given username and password to the userpass auth
+//endpoint. If a username with that password exists, then the AuthOutput object
+//is returned, and this client's AuthToken is set to the returned token.
+func (v *Client) AuthUserpass(username, password string) (ret *AuthOutput, err error) {
+	ret = &AuthOutput{Metadata: AuthUserpassMetadata{}}
+	err = v.doRequest(
+		"POST",
+		fmt.Sprintf("/auth/userpass/login/%s", username),
+		struct {
+			Password string `json:"password"`
+		}{Password: password},
+		&ret,
+	)
+
+	if err == nil {
+		v.AuthToken = ret.Auth.ClientToken
+	}
+
+	return
+}
+
+//TokenRenewSelf takes the token in the Client object and attempts to renew its
+// lease.
+func (v *Client) TokenRenewSelf() (err error) {
+	return v.doRequest("POST", "/auth/token/renew-self", nil, nil)
+}
+
+//TokenIsValid returns no error if it can look itself up. This can error
+// if the token is valid but somebody has configured policies such that it can not
+// look itself up. It can also error, of course, if the token is invalid.
+func (v *Client) TokenIsValid() (err error) {
+	return v.doRequest("GET", "/auth/token/lookup-self", nil, nil)
+}

--- a/vendor/github.com/cloudfoundry-community/vaultkv/client.go
+++ b/vendor/github.com/cloudfoundry-community/vaultkv/client.go
@@ -1,0 +1,133 @@
+//Package vaultkv provides a client with functions that make API calls that a user of
+// Vault may commonly want.
+package vaultkv
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+)
+
+//Client provides functions that access and abstract the Vault API.
+// VaultURL must be set to the for the client to work. Only Vault versions
+// 0.6.5 and above are tested to work with this client.
+type Client struct {
+	AuthToken string
+	VaultURL  *url.URL
+	//If Client is nil, http.DefaultClient will be used
+	Client *http.Client
+	//If Trace is non-nil, information about HTTP requests will be given into the
+	//Writer.
+	Trace io.Writer
+}
+
+type vaultResponse struct {
+	Data interface{} `json:"data"`
+	//There's totally more to the response, but this is all I care about atm.
+}
+
+//URL encoded values can be given as a *url.Values as "input" when performing
+// a GET call
+func (v *Client) doRequest(
+	method, path string,
+	input interface{},
+	output interface{}) error {
+
+	u := *v.VaultURL
+	u.Path = fmt.Sprintf("/v1/%s", strings.Trim(path, "/"))
+	if u.Port() == "" {
+		u.Host = fmt.Sprintf("%s:8200", u.Host)
+	}
+
+	var query url.Values
+	var body io.Reader
+	if input != nil {
+		if strings.ToUpper(method) == "GET" {
+			//Input has to be a url.Values
+			query = input.(url.Values)
+		} else {
+			body = &bytes.Buffer{}
+			err := json.NewEncoder(body.(*bytes.Buffer)).Encode(input)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	resp, err := v.Curl(method, path, query, body)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode/100 != 2 {
+		return v.parseError(resp)
+	}
+
+	if output != nil && resp.StatusCode == 200 {
+		err = json.NewDecoder(resp.Body).Decode(output)
+	}
+
+	return err
+}
+
+//Curl takes the given path, prepends <VaultURL>/v1/ to it, and makes the request
+// with the remainder of the given parameters. Errors returned only reflect
+// transport errors, not HTTP semantic errors
+func (v *Client) Curl(method string, path string, urlQuery url.Values, body io.Reader) (*http.Response, error) {
+	//Setup URL
+	u := *v.VaultURL
+	u.Path = fmt.Sprintf("/v1/%s", strings.Trim(path, "/"))
+	if u.Port() == "" {
+		u.Host = fmt.Sprintf("%s:8200", u.Host)
+	}
+	u.RawQuery = urlQuery.Encode()
+
+	//Do the request
+	req, err := http.NewRequest(method, u.String(), body)
+	if err != nil {
+		return nil, err
+	}
+	if v.Trace != nil {
+		dump, _ := httputil.DumpRequest(req, true)
+		v.Trace.Write([]byte(fmt.Sprintf("Request:\n%s\n", dump)))
+	}
+
+	token := v.AuthToken
+	if token == "" {
+		token = "01234567-89ab-cdef-0123-456789abcdef"
+	}
+	req.Header.Set("X-Vault-Token", token)
+
+	client := v.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	if client.CheckRedirect == nil {
+		client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			if len(via) > 10 {
+				return fmt.Errorf("Stopped after 10 redirects")
+			}
+			req.Header.Set("X-Vault-Token", token)
+			return nil
+		}
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, &ErrTransport{message: err.Error()}
+	}
+
+	if v.Trace != nil {
+		dump, _ := httputil.DumpResponse(resp, true)
+		v.Trace.Write([]byte(fmt.Sprintf("Response:\n%s\n", dump)))
+	}
+
+	return resp, nil
+}

--- a/vendor/github.com/cloudfoundry-community/vaultkv/errors.go
+++ b/vendor/github.com/cloudfoundry-community/vaultkv/errors.go
@@ -1,0 +1,191 @@
+package vaultkv
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+)
+
+//ErrBadRequest represents 400 status codes that are returned from the API.
+//See: your fault.
+type ErrBadRequest struct {
+	message string
+}
+
+func (e *ErrBadRequest) Error() string {
+	return e.message
+}
+
+//IsBadRequest returns true if the error is an ErrBadRequest
+func IsBadRequest(err error) bool {
+	_, is := err.(*ErrBadRequest)
+	return is
+}
+
+//ErrForbidden represents 403 status codes returned from the API. This could be
+// if your auth is wrong or expired, or you simply don't have access to do the
+// particular thing you're trying to do. Check your privilege.
+type ErrForbidden struct {
+	message string
+}
+
+func (e *ErrForbidden) Error() string {
+	return e.message
+}
+
+//IsForbidden returns true if the error is an ErrForbidden
+func IsForbidden(err error) bool {
+	_, is := err.(*ErrForbidden)
+	return is
+}
+
+//ErrNotFound represents 404 status codes returned from the API. This could be
+// either that the thing you're looking for doesn't exist, or in some cases
+// that you don't have access to the thing you're looking for and that Vault is
+// hiding it from you.
+type ErrNotFound struct {
+	message string
+}
+
+func (e *ErrNotFound) Error() string {
+	return e.message
+}
+
+//IsNotFound returns true if the error is an ErrNotFound
+func IsNotFound(err error) bool {
+	_, is := err.(*ErrNotFound)
+	return is
+}
+
+//ErrStandby is only returned from Health() if standbyok is set to false and the
+// node you're querying is a standby.
+type ErrStandby struct {
+	message string
+}
+
+func (e *ErrStandby) Error() string {
+	return e.message
+}
+
+//IsErrStandby returns true if the error is an ErrStandby
+func IsErrStandby(err error) bool {
+	_, is := err.(*ErrStandby)
+	return is
+}
+
+//ErrInternalServer represents 500 status codes that are returned from the API.
+//See: their fault.
+type ErrInternalServer struct {
+	message string
+}
+
+func (e *ErrInternalServer) Error() string {
+	return e.message
+}
+
+//IsInternalServer returns true if the error is an ErrInternalServer
+func IsInternalServer(err error) bool {
+	_, is := err.(*ErrInternalServer)
+	return is
+}
+
+//ErrSealed represents the 503 status code that is returned by Vault most
+// commonly if the Vault is currently sealed, but could also represent the Vault
+// being in a maintenance state.
+type ErrSealed struct {
+	message string
+}
+
+func (e *ErrSealed) Error() string {
+	return e.message
+}
+
+//IsSealed returns true if the error is an ErrSealed
+func IsSealed(err error) bool {
+	_, is := err.(*ErrSealed)
+	return is
+}
+
+//ErrUninitialized represents a 503 status code being returned and the Vault
+//being uninitialized.
+type ErrUninitialized struct {
+	message string
+}
+
+func (e *ErrUninitialized) Error() string {
+	return e.message
+}
+
+//IsUninitialized returns true if the error is an ErrUninitialized
+func IsUninitialized(err error) bool {
+	_, is := err.(*ErrUninitialized)
+	return is
+}
+
+//ErrTransport is returned if an error was encountered trying to reach the API,
+// as opposed to an error from the API, is returned
+type ErrTransport struct {
+	message string
+}
+
+func (e *ErrTransport) Error() string {
+	return e.message
+}
+
+//IsTransport returns true if the error is an ErrTransport
+func IsTransport(err error) bool {
+	_, is := err.(*ErrTransport)
+	return is
+}
+
+//ErrKVUnsupported is returned by the KV object when the user requests an
+// operation that cannot be performed by the actual version of the KV backend
+// that the KV object is abstracting
+type ErrKVUnsupported struct {
+	message string
+}
+
+func (e *ErrKVUnsupported) Error() string {
+	return e.message
+}
+
+//IsErrKVUnsupported returns true if the error is an ErrKVUnsupported
+func IsErrKVUnsupported(err error) bool {
+	_, is := err.(*ErrKVUnsupported)
+	return is
+}
+
+type apiError struct {
+	Errors []string `json:"errors"`
+}
+
+func (v *Client) parseError(r *http.Response) (err error) {
+	errorsStruct := apiError{}
+	err = json.NewDecoder(r.Body).Decode(&errorsStruct)
+	if err != nil {
+		return err
+	}
+	errorMessage := strings.Join(errorsStruct.Errors, "\n")
+
+	switch r.StatusCode {
+	case 400:
+		err = &ErrBadRequest{message: errorMessage}
+	case 403:
+		err = &ErrForbidden{message: errorMessage}
+	case 404:
+		err = &ErrNotFound{message: errorMessage}
+	case 500:
+		err = &ErrInternalServer{message: errorMessage}
+	case 503:
+		err = v.parse503(errorMessage)
+	default:
+		err = errors.New(errorMessage)
+	}
+
+	return
+}
+
+func (v *Client) parse503(message string) (err error) {
+	return v.Health(true)
+}

--- a/vendor/github.com/cloudfoundry-community/vaultkv/kv.go
+++ b/vendor/github.com/cloudfoundry-community/vaultkv/kv.go
@@ -1,0 +1,418 @@
+package vaultkv
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+//KV provides an abstraction to the Vault tree which makes dealing with
+// the potential of both KV v1 and KV v2 backends easier to work with.
+// KV v1 backends are exposed through this interface much like KV v2
+// backends with only one version. There are limitations around Delete
+// and Undelete calls because of the lack of versioning in KV v1 backends.
+// See the documentation around those functions for more details.
+// An empty KV struct is not request-ready. Please call Client.NewKV instead.
+type KV struct {
+	Client *Client
+	//Map from mount name to [true if version 2. False otherwise]
+	mounts map[string]kvMount
+	lock   sync.RWMutex
+}
+
+type kvMount interface {
+	Get(mount, subpath string, output interface{}, opts *KVGetOpts) (meta KVVersion, err error)
+	Set(mount, subpath string, values map[string]string, opts *KVSetOpts) (meta KVVersion, err error)
+	List(mount, subpath string) (paths []string, err error)
+	Delete(mount, subpath string, opts *KVDeleteOpts) (err error)
+	Undelete(mount, subpath string, versions []uint) (err error)
+	Destroy(mount, subpath string, versions []uint) (err error)
+	DestroyAll(mount, subpath string) (err error)
+	Versions(mount, subpath string) (ret []KVVersion, err error)
+	MountVersion() (version uint)
+}
+
+/*====================
+        KV V1
+====================*/
+type kvv1Mount struct {
+	client *Client
+}
+
+func v1ConstructPath(mount, subpath string) string {
+	mount = strings.Trim(mount, "/")
+	subpath = strings.Trim(subpath, "/")
+	return strings.Trim(fmt.Sprintf("%s/%s", mount, subpath), "/")
+}
+
+func (k kvv1Mount) Get(mount, subpath string, output interface{}, opts *KVGetOpts) (meta KVVersion, err error) {
+	if opts != nil && opts.Version > 1 {
+		err = &ErrNotFound{"No versions greater than one in KV v1 backend"}
+		return
+	}
+
+	path := v1ConstructPath(mount, subpath)
+	err = k.client.Get(path, output)
+	if err == nil {
+		meta.Version = 1
+	}
+	return
+}
+
+func (k kvv1Mount) List(mount, subpath string) (paths []string, err error) {
+	path := v1ConstructPath(mount, subpath)
+	return k.client.List(path)
+}
+
+func (k kvv1Mount) Set(mount, subpath string, values map[string]string, opts *KVSetOpts) (meta KVVersion, err error) {
+	path := v1ConstructPath(mount, subpath)
+	err = k.client.Set(path, values)
+	if err == nil {
+		meta.Version = 1
+	}
+	return
+}
+
+func (k kvv1Mount) Delete(mount, subpath string, opts *KVDeleteOpts) (err error) {
+	if opts == nil || !opts.V1Destroy {
+		return &ErrKVUnsupported{"Refusing to destroy KV v1 value from delete call"}
+	}
+
+	versions := []uint{}
+	if opts != nil {
+		versions = opts.Versions
+	}
+
+	return k.Destroy(mount, subpath, versions)
+}
+
+func (k kvv1Mount) Undelete(mount, subpath string, versions []uint) (err error) {
+	return &ErrKVUnsupported{"Cannot undelete secret in KV v1 backend"}
+}
+
+func (k kvv1Mount) Destroy(mount, subpath string, versions []uint) (err error) {
+	shouldDelete := len(versions) == 0
+	for _, v := range versions {
+		if v <= 1 {
+			shouldDelete = true
+		}
+	}
+
+	if shouldDelete {
+		path := v1ConstructPath(mount, subpath)
+		err = k.client.Delete(path)
+	}
+	return err
+}
+
+func (k kvv1Mount) DestroyAll(mount, subpath string) (err error) {
+	path := v1ConstructPath(mount, subpath)
+	return k.client.Delete(path)
+}
+
+func (k kvv1Mount) Versions(mount, subpath string) (ret []KVVersion, err error) {
+	path := v1ConstructPath(mount, subpath)
+	err = k.client.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+	ret = []KVVersion{{Version: 1}}
+	return
+}
+
+func (k kvv1Mount) MountVersion() (version uint) {
+	return 1
+}
+
+/*====================
+        KV V2
+====================*/
+type kvv2Mount struct {
+	client *Client
+}
+
+func (k kvv2Mount) Get(mount, subpath string, output interface{}, opts *KVGetOpts) (meta KVVersion, err error) {
+	var o *V2GetOpts
+	if opts != nil {
+		o = &V2GetOpts{
+			Version: opts.Version,
+		}
+	}
+
+	var m V2Version
+	m, err = k.client.V2Get(mount, subpath, output, o)
+	if err == nil {
+		meta.Deleted = m.DeletedAt != nil
+		meta.Destroyed = m.Destroyed
+		meta.Version = m.Version
+	}
+	return
+}
+
+func (k kvv2Mount) List(mount, subpath string) (paths []string, err error) {
+	return k.client.V2List(mount, subpath)
+}
+
+func (k kvv2Mount) Set(mount, subpath string, values map[string]string, opts *KVSetOpts) (meta KVVersion, err error) {
+	var m V2Version
+	m, err = k.client.V2Set(mount, subpath, values, nil)
+	if err == nil {
+		meta.Version = m.Version
+	}
+	return
+}
+
+func (k kvv2Mount) Delete(mount, subpath string, opts *KVDeleteOpts) (err error) {
+	versions := []uint{}
+	if opts != nil {
+		versions = opts.Versions
+	}
+	return k.client.V2Delete(mount, subpath, &V2DeleteOpts{Versions: versions})
+}
+
+func (k kvv2Mount) Undelete(mount, subpath string, versions []uint) (err error) {
+	return k.client.V2Undelete(mount, subpath, versions)
+}
+
+func (k kvv2Mount) Destroy(mount, subpath string, versions []uint) (err error) {
+	return k.client.V2Destroy(mount, subpath, versions)
+}
+
+func (k kvv2Mount) DestroyAll(mount, subpath string) (err error) {
+	return k.client.V2DestroyMetadata(mount, subpath)
+}
+
+func (k kvv2Mount) Versions(mount, subpath string) (ret []KVVersion, err error) {
+	var meta V2Metadata
+	meta, err = k.client.V2GetMetadata(mount, subpath)
+	if err != nil {
+		return nil, err
+	}
+
+	ret = make([]KVVersion, len(meta.Versions))
+	for i := range meta.Versions {
+		ret[i].Deleted = meta.Versions[i].DeletedAt != nil
+		ret[i].Destroyed = meta.Versions[i].Destroyed
+		ret[i].Version = meta.Versions[i].Version
+	}
+	return
+}
+
+func (k kvv2Mount) MountVersion() (version uint) {
+	return 2
+}
+
+/*==========================
+       KV Abstraction
+==========================*/
+
+//NewKV returns an initialized KV object.
+func (v *Client) NewKV() *KV {
+	return &KV{Client: v, mounts: map[string]kvMount{}}
+}
+
+func (k *KV) mountForPath(path string) (mountPath string, ret kvMount, err error) {
+	pathParts := strings.Split(strings.Trim(path, "/"), "/")
+	var found bool
+	k.lock.RLock()
+	for i := 1; i <= len(pathParts); i++ {
+		mountPath = strings.Join(pathParts[:i], "/")
+		ret, found = k.mounts[mountPath]
+		if found {
+			break
+		}
+	}
+	k.lock.RUnlock()
+	if found {
+		return
+	}
+
+	k.lock.Lock()
+	defer k.lock.Unlock()
+	for i := 1; i <= len(pathParts); i++ {
+		mountPath = strings.Join(pathParts[:i], "/")
+		ret, found = k.mounts[mountPath]
+		if found {
+			break
+		}
+	}
+	if found {
+		return
+	}
+
+	mountPath, isV2, err := k.Client.IsKVv2Mount(path)
+	if err != nil {
+		return
+	}
+
+	ret = kvv1Mount{k.Client}
+	if isV2 {
+		ret = kvv2Mount{k.Client}
+	}
+
+	k.mounts[mountPath] = ret
+
+	return
+}
+
+func subtractMount(mount string, path string) string {
+	mount = strings.Trim(mount, "/")
+	path = strings.Trim(path, "/")
+	var ret string
+	if mount != path {
+		ret = strings.Trim(strings.TrimPrefix(path, mount), "/")
+	}
+	return ret
+}
+
+//KVGetOpts are options applicable to KV.Get
+type KVGetOpts struct {
+	// Version is the version of the resource to retrieve. Setting this to zero (or
+	// not setting it at all) will retrieve the latest version
+	Version uint
+}
+
+//KVVersion contains information about a version of a secret.
+type KVVersion struct {
+	Version   uint
+	Deleted   bool
+	Destroyed bool
+}
+
+//Get retrieves the value at the given path in the tree. This follows the
+//semantics of Client.Get or Client.V2Get, chosen based on the backend mounted
+//at the path given.
+func (k *KV) Get(path string, output interface{}, opts *KVGetOpts) (meta KVVersion, err error) {
+	mountPath, mount, err := k.mountForPath(path)
+	if err != nil {
+		return
+	}
+
+	path = subtractMount(mountPath, path)
+	return mount.Get(mountPath, path, output, opts)
+}
+
+//List retrieves the paths under the given path. If the path does not exist or
+//it is not a folder, ErrNotFound is thrown. Results ending with a slash are
+//folders.
+func (k *KV) List(path string) (paths []string, err error) {
+	mountPath, mount, err := k.mountForPath(path)
+	if err != nil {
+		return
+	}
+
+	path = subtractMount(mountPath, path)
+	return mount.List(mountPath, path)
+}
+
+//KVSetOpts are the options for a set call to the KV.Set() call. Currently there
+// are none, but it exists in case the API adds support in the future for things
+// that we can put here.
+type KVSetOpts struct{}
+
+//Set puts the values given at the path given. If KV v1, the previous value, if
+//any, is overwritten.  If KV v2, a new version is created.
+func (k *KV) Set(path string, values map[string]string, opts *KVSetOpts) (meta KVVersion, err error) {
+	mountPath, mount, err := k.mountForPath(path)
+	if err != nil {
+		return
+	}
+
+	path = subtractMount(mountPath, path)
+	return mount.Set(mountPath, path, values, opts)
+}
+
+//KVDeleteOpts are options applicable to KV.Delete
+type KVDeleteOpts struct {
+	//Versions are the versions of the secret to delete. If left nil,
+	// the latest version is deleted.
+	Versions []uint
+	//V1Destroy, if true, will call Client.Delete if the given path
+	// to delete is a V1 backend (thus permanently destroying the secret).
+	// If it is false and the backend is V1, an ErrKVUnsupported error will
+	// be thrown. This has no effect on KV v2 backends.
+	V1Destroy bool
+}
+
+//Delete attempts to mark the secret at the given path (and version) as deleted.
+// For KV v1, temporarily deleting a secret is not possible. Use the V1Destroy
+// option as a way to safeguard against unwanted destruction of secrets.
+func (k *KV) Delete(path string, opts *KVDeleteOpts) (err error) {
+	mountPath, mount, err := k.mountForPath(path)
+	if err != nil {
+		return
+	}
+
+	path = subtractMount(mountPath, path)
+	return mount.Delete(mountPath, path, opts)
+}
+
+//Undelete attempts to unmark deletion on a previously deleted version.
+// KV v1 backends cannot do this, and so if the backend is KV v1, this
+// returns an ErrKVUnsupported.
+func (k *KV) Undelete(path string, versions []uint) (err error) {
+	mountPath, mount, err := k.mountForPath(path)
+	if err != nil {
+		return
+	}
+
+	path = subtractMount(mountPath, path)
+	return mount.Undelete(mountPath, path, versions)
+}
+
+//Destroy attempts to irrevocably delete the given versions at the given
+// path. For KV v1 backends, this is a call to Client.Delete. for KV v2
+// backends, this is a call to Client.V2Destroy
+func (k *KV) Destroy(path string, versions []uint) (err error) {
+	mountPath, mount, err := k.mountForPath(path)
+	if err != nil {
+		return
+	}
+
+	path = subtractMount(mountPath, path)
+	return mount.Destroy(mountPath, path, versions)
+}
+
+//DestroyAll attempts to irrevocably delete all versions of the secret
+// at the given path. For KV v1 backends, this is a call to Client.Delete.
+// For v2 backends, this is a call to Client.V2DestroyMetadata
+func (k *KV) DestroyAll(path string) (err error) {
+	mountPath, mount, err := k.mountForPath(path)
+	if err != nil {
+		return
+	}
+
+	path = subtractMount(mountPath, path)
+	return mount.DestroyAll(mountPath, path)
+}
+
+//Versions returns the versions of the secret available. If no secret
+// exists at this path, ErrNotFound is returned. If the secret exists
+// and this is a KV v1 backend, one version is returned.
+func (k *KV) Versions(path string) (ret []KVVersion, err error) {
+	mountPath, mount, err := k.mountForPath(path)
+	if err != nil {
+		return
+	}
+
+	path = subtractMount(mountPath, path)
+	return mount.Versions(mountPath, path)
+}
+
+//MountVersion returns the KV version of the mount for the given path.
+// v1 mounts return 1; v2 mounts return 2.
+func (k *KV) MountVersion(mount string) (version uint, err error) {
+	_, m, err := k.mountForPath(mount)
+	if err != nil {
+		return
+	}
+
+	return m.MountVersion(), nil
+}
+
+//MountPath returns the path of the mount on which the given path is mounted.
+// If no such mount can be found, an error is returned.
+func (k *KV) MountPath(path string) (mount string, err error) {
+	mount, _, err = k.mountForPath(path)
+	return
+}

--- a/vendor/github.com/cloudfoundry-community/vaultkv/kv1.go
+++ b/vendor/github.com/cloudfoundry-community/vaultkv/kv1.go
@@ -1,0 +1,68 @@
+package vaultkv
+
+import (
+	"fmt"
+	"reflect"
+)
+
+//Get retrieves the secret at the given path and unmarshals it into the given
+//output object using the semantics of encoding/json.Unmarshal. If the object
+//is nil, an unmarshal will not be attempted (this can be used to check for
+//existence). If the object could not be unmarshalled into, the resultant error
+//is returned. Example path would be /secret/foo, if Key/Value backend were
+//mounted at "/secret". The Vault must be unsealed and initialized for this
+//endpoint to work. No assumptions are made about the mounting point of your
+//Key/Value backend.
+func (v *Client) Get(path string, output interface{}) error {
+	if output != nil &&
+		reflect.ValueOf(output).Kind() != reflect.Ptr {
+		return fmt.Errorf("Get output target must be a pointer if non-nil")
+	}
+
+	err := v.doRequest("GET", path, nil, &vaultResponse{Data: output})
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+//List returns the list of paths nested directly under the given path. If this
+//is not a "directory" for any paths, then ErrNotFound is returned. In the list
+//of paths returned on success, if a path ends with a slash, then it is also a
+//"directory". The Vault must be unsealed and initialized for this endpoint to
+//work. No assumptions are made about the mounting point of your Key/Value
+//backend.
+func (v *Client) List(path string) ([]string, error) {
+	ret := []string{}
+
+	err := v.doRequest("LIST", path, nil, &vaultResponse{
+		Data: &struct {
+			Keys *[]string `json:"keys"`
+		}{
+			Keys: &ret,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return ret, err
+}
+
+//Set puts the values in the given map at the given path. The keys in the map
+//become the keys at the path, and the values in the map become the values of
+//those keys. The Vault must be unsealed and initialized for this endpoint to
+//work. No assumptions are made about the mounting point of your Key/Value
+//backend.
+func (v *Client) Set(path string, values map[string]string) error {
+	//TODO: This function should be changed to accept a map[string]interface{}
+	//Then tests should be written for cases other than map[string]string
+	return v.doRequest("PUT", path, &values, nil)
+}
+
+//Delete attempts to delete the value at the specified path. No error is
+//returned if there is already no value at the given path.
+func (v *Client) Delete(path string) error {
+	return v.doRequest("DELETE", path, nil, nil)
+}

--- a/vendor/github.com/cloudfoundry-community/vaultkv/kv2.go
+++ b/vendor/github.com/cloudfoundry-community/vaultkv/kv2.go
@@ -1,0 +1,390 @@
+package vaultkv
+
+import (
+	"fmt"
+	"net/url"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+//Use some heuristics to determine what is the most likely mount path if Vault won't
+// tell us with its old, crusty version
+func mountPathDefault(path string) string {
+	path = strings.TrimLeft(path, "/")
+	var prefix string
+	if strings.HasPrefix(path, "auth/") {
+		path = strings.TrimPrefix(path, "auth/")
+		prefix = "auth/"
+	}
+
+	return fmt.Sprintf("%s%s", prefix, strings.Split(path, "/")[0])
+}
+
+//IsKVv2Mount returns true if the mount is a version 2 KV mount and false
+//otherwise. This will also simply return false if no mount exists at the given
+//mount point or if the Vault is too old to have the API endpoint to look for
+//the mount. If a different API error occurs, it will be propagated out.
+func (c *Client) IsKVv2Mount(path string) (mountPath string, isV2 bool, err error) {
+	path = strings.TrimPrefix(path, "/")
+	output := struct {
+		Data struct {
+			Secret map[string]struct {
+				Type    string `json:"type"`
+				Options struct {
+					Version string `json:"version"`
+				} `json:"options"`
+			} `json:"secret"`
+		} `json:"data"`
+	}{}
+
+	err = c.doRequest(
+		"GET",
+		fmt.Sprintf("/sys/internal/ui/mounts"),
+		nil, &output)
+
+	mountPath = strings.Trim(mountPathDefault(path), "/")
+	if err != nil {
+		//If we got a 404, this version of Vault is too old to possibly have a v2 backend
+		if _, is404 := err.(*ErrNotFound); is404 {
+			err = nil
+		}
+
+		//Then either the token is invalid (and we should err) or this could be
+		// an old version of Vault that doesn't have this endpoint yet, and so its
+		// interpreting this as a call to the sys/* region which this token may not have
+		// access to. In this case, it would be too old of a version to have a v2 backend.
+		if _, is403 := err.(*ErrForbidden); is403 {
+			if c.TokenIsValid() == nil {
+				err = nil
+			}
+		}
+
+		return
+	}
+
+	if output.Data.Secret == nil {
+		return
+	}
+
+	path = strings.Replace(path, "//", "/", -1)
+	path = strings.Trim(path, "/")
+	pathSplit := strings.Split(path, "/")
+
+	for i := 1; i <= len(pathSplit); i++ {
+		thisPath := strings.Join(pathSplit[:i], "/") + "/"
+		if out, found := output.Data.Secret[thisPath]; found {
+			mountPath = strings.TrimRight(thisPath, "/")
+			isV2 = out.Options.Version == "2"
+			break
+		}
+	}
+
+	return
+}
+
+//SplitMount takes the given path and splits it into the respective mount name
+// and path under the mount and returns both parts
+func SplitMount(path string) (mount string, subpath string) {
+	path = strings.TrimLeft(path, "/")
+	splits := strings.SplitN(path, "/", 2)
+	mount = splits[0]
+	if len(splits) > 1 {
+		subpath = splits[1]
+	}
+
+	subpath = fmt.Sprintf("/%s", strings.TrimLeft(subpath, "/"))
+	return
+}
+
+//V2Version is information about a version of a secret. The DeletedAt member
+// will be nil to signify that a version is not deleted. Take note of the
+// difference between "deleted" and "destroyed" - a deletion simply marks a
+// secret as deleted, preventing it from being read. A destruction actually
+// removes the data from storage irrevocably.
+type V2Version struct {
+	CreatedAt time.Time
+	DeletedAt *time.Time
+	Destroyed bool
+	Version   uint
+}
+
+type v2VersionAPI struct {
+	CreatedTime  string `json:"created_time"`
+	DeletionTime string `json:"deletion_time"`
+	Destroyed    bool   `json:"destroyed"`
+	Version      uint   `json:"version"`
+}
+
+func (v v2VersionAPI) Parse() V2Version {
+	ret := V2Version{
+		Destroyed: v.Destroyed,
+		Version:   v.Version,
+	}
+
+	//Parse those times
+	ret.CreatedAt, _ = time.Parse(time.RFC3339Nano, v.CreatedTime)
+	tmpDeletion, err := time.Parse(time.RFC3339Nano, v.DeletionTime)
+	if err == nil {
+		ret.DeletedAt = &tmpDeletion
+	}
+
+	return ret
+}
+
+//V2GetOpts are options to specify in a V2Get request.
+type V2GetOpts struct {
+	// Version is the version of the resource to retrieve. Setting this to zero (or
+	// not setting it at all) will retrieve the latest version
+	Version uint
+}
+
+//V2Get will get a secret from the given path in a KV version 2 secrets backend.
+//If the secret is at "/bar" in the backend mounted at "foo", then the path
+//should be "foo/bar". The response will be decoded into the item pointed to
+//by output using encoding/json.Unmarshal semantics. The version to retrieve
+//can be selected by setting Version in the V2GetOpts struct at opts.
+func (c *Client) V2Get(mount, subpath string, output interface{}, opts *V2GetOpts) (meta V2Version, err error) {
+	if output != nil &&
+		reflect.ValueOf(output).Kind() != reflect.Ptr {
+		err = fmt.Errorf("V2Get output target must be a pointer if non-nil")
+		return
+	}
+
+	type outputData struct {
+		Metadata v2VersionAPI `json:"metadata"`
+		Data     interface{}  `json:"data"`
+	}
+
+	unmarshalInto := &struct {
+		Data outputData `json:"data"`
+	}{
+		Data: outputData{
+			Metadata: v2VersionAPI{},
+			Data:     output,
+		},
+	}
+
+	query := url.Values{}
+	if opts != nil {
+		query.Add("version", strconv.FormatUint(uint64(opts.Version), 10))
+	}
+
+	path := fmt.Sprintf("%s/data/%s", strings.Trim(mount, "/"), strings.Trim(subpath, "/"))
+	err = c.doRequest("GET", path, query, unmarshalInto)
+	if err != nil {
+		return
+	}
+
+	meta = unmarshalInto.Data.Metadata.Parse()
+	return
+}
+
+//V2List returns the list of paths nested directly under the given path. If this
+//is not a "directory" for any paths, then ErrNotFound is returned. In the list
+//of paths returned on success, if a path ends with a slash, then it is also a
+//"directory". The Vault must be unsealed and initialized for this endpoint to
+//work. No assumptions are made about the mounting point of your Key/Value
+//backend.
+func (v *Client) V2List(mount, subpath string) ([]string, error) {
+	ret := []string{}
+	path := fmt.Sprintf("%s/metadata/%s", strings.Trim(mount, "/"), strings.Trim(subpath, "/"))
+
+	err := v.doRequest("LIST", path, nil, &vaultResponse{
+		Data: &struct {
+			Keys *[]string `json:"keys"`
+		}{
+			Keys: &ret,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return ret, err
+}
+
+//V2SetOpts are options that can be specified to a V2Set call
+type V2SetOpts struct {
+	//CAS provides a check-and-set version number. If this is set to zero, then
+	// the value will only be written if the key does not yet exist. If the CAS
+	//number is non-zero, then this will only be written if the current version
+	//for your this secret matches the CAS value.
+	CAS *uint `json:"cas,omitempty"`
+}
+
+//WithCAS returns a pointer to a new V2SetOpts with the CAS value set to the
+//given value. If i is zero, then the value will only be written if the key
+//does not exist. If i is non-zero, then the value will only be written if the
+//currently existing version matches i. Not calling CAS will result in no
+//restriction on writing. If the mount is set up for requiring CAS, then not
+//setting CAS with this function a valid number will result in a failure when
+//attempting to write.
+func (s V2SetOpts) WithCAS(i uint) *V2SetOpts {
+	s.CAS = new(uint)
+	*s.CAS = i
+	return &s
+}
+
+//V2Set uses encoding/json.Marshal on the object given in values to encode
+// the secret as JSON, and writes it to the path given. Populate ops to use the
+// check-and-set functionality. Returns the metadata about the written secret
+// if the write is successful.
+func (c *Client) V2Set(mount, subpath string, values interface{}, opts *V2SetOpts) (meta V2Version, err error) {
+	input := struct {
+		Options *V2SetOpts  `json:"options,omitempty"`
+		Data    interface{} `json:"data"`
+	}{
+		Options: opts,
+		Data:    &values,
+	}
+
+	output := struct {
+		Data v2VersionAPI `json:"data"`
+	}{
+		Data: v2VersionAPI{},
+	}
+
+	path := fmt.Sprintf("%s/data/%s", strings.Trim(mount, "/"), strings.Trim(subpath, "/"))
+
+	err = c.doRequest("PUT", path, &input, &output)
+	if err != nil {
+		return
+	}
+
+	meta = output.Data.Parse()
+	return
+}
+
+//V2DeleteOpts are options that can be provided to a V2Delete call.
+type V2DeleteOpts struct {
+	Versions []uint `json:"versions"`
+}
+
+//V2Delete marks a secret version at the given path as deleted. If opts is not
+// provided or the Versions slice therein is left nil, the latest version is
+// deleted. Otherwise, the specified versions are deleted. Note that the deleted
+// data from this call is recoverable from a call to V2Undelete.
+func (c *Client) V2Delete(mount, subpath string, opts *V2DeleteOpts) error {
+	method := "DELETE"
+	path := fmt.Sprintf("%s/data/%s", strings.Trim(mount, "/"), strings.Trim(subpath, "/"))
+
+	if opts != nil && len(opts.Versions) > 0 {
+		method = "POST"
+		path = fmt.Sprintf("%s/delete/%s", strings.Trim(mount, "/"), strings.Trim(subpath, "/"))
+	} else {
+		opts = nil
+	}
+
+	return c.doRequest(method, path, opts, nil)
+}
+
+//V2Undelete marks the specified versions at the specified paths as not deleted.
+func (c *Client) V2Undelete(mount, subpath string, versions []uint) error {
+	path := fmt.Sprintf("%s/undelete/%s", strings.Trim(mount, "/"), strings.Trim(subpath, "/"))
+	return c.doRequest("POST", path, struct {
+		Versions []uint `json:"versions"`
+	}{
+		Versions: versions,
+	}, nil)
+}
+
+//V2Destroy permanently deletes the specified versions at the specified path.
+func (c *Client) V2Destroy(mount, subpath string, versions []uint) error {
+	path := fmt.Sprintf("%s/destroy/%s", strings.Trim(mount, "/"), strings.Trim(subpath, "/"))
+	return c.doRequest("POST", path, struct {
+		Versions []uint `json:"versions"`
+	}{
+		Versions: versions,
+	}, nil)
+}
+
+//V2DestroyMetadata permanently destroys all secret versions and all metadata
+// associated with the secret at the specified path.
+func (c *Client) V2DestroyMetadata(mount, subpath string) error {
+	path := fmt.Sprintf("%s/metadata/%s", strings.Trim(mount, "/"), strings.Trim(subpath, "/"))
+	return c.doRequest("DELETE", path, nil, nil)
+}
+
+//V2Metadata is the metadata associated with a secret
+type V2Metadata struct {
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	//CurrentVersion is the highest version number that has been created for this
+	//secret. Deleteing or destroying the highest version does not change this
+	//number.
+	CurrentVersion uint
+	OldestVersion  uint
+	MaxVersions    uint
+	Versions       []V2Version
+}
+
+type v2MetadataAPI struct {
+	Data struct {
+		CreatedTime    string                  `json:"created_time"`
+		CurrentVersion uint                    `json:"current_version"`
+		MaxVersions    uint                    `json:"max_versions"`
+		OldestVersion  uint                    `json:"oldest_version"`
+		UpdatedTime    string                  `json:"updated_time"`
+		Versions       map[string]v2VersionAPI `json:"versions"`
+	} `json:"data"`
+}
+
+//Version returns the version with the given number in the metadata as a
+//V2Version object , if present. If no version with that number is present, an
+//error is returned.
+func (m V2Metadata) Version(number uint) (version V2Version, err error) {
+	if len(m.Versions) == 0 {
+		err = fmt.Errorf("That version does not exist in the metadata")
+		return
+	}
+
+	firstVersion := m.Versions[0]
+	index := int(number) - int(firstVersion.Version)
+	if index < 0 || index > len(m.Versions) {
+		err = fmt.Errorf("That version does not exist in the metadata")
+		return
+	}
+
+	version = m.Versions[index]
+	return
+}
+
+func (m v2MetadataAPI) Parse() V2Metadata {
+	ret := V2Metadata{
+		CurrentVersion: m.Data.CurrentVersion,
+		MaxVersions:    m.Data.MaxVersions,
+		OldestVersion:  m.Data.OldestVersion,
+	}
+
+	ret.CreatedAt, _ = time.Parse(time.RFC3339Nano, m.Data.CreatedTime)
+	ret.UpdatedAt, _ = time.Parse(time.RFC3339Nano, m.Data.UpdatedTime)
+
+	for number, metadata := range m.Data.Versions {
+		toAdd := metadata.Parse()
+		version64, _ := strconv.ParseUint(number, 10, 64)
+		toAdd.Version = uint(version64)
+		ret.Versions = append(ret.Versions, toAdd)
+	}
+
+	sort.Slice(ret.Versions,
+		func(i, j int) bool { return ret.Versions[i].Version < ret.Versions[j].Version },
+	)
+
+	return ret
+}
+
+//V2GetMetadata gets the metadata associated with the secret at the specified
+// path.
+func (c *Client) V2GetMetadata(mount, subpath string) (meta V2Metadata, err error) {
+	path := fmt.Sprintf("%s/metadata/%s", strings.Trim(mount, "/"), strings.Trim(subpath, "/"))
+	output := v2MetadataAPI{}
+	err = c.doRequest("GET", path, nil, &output)
+	if err != nil {
+		return
+	}
+	meta = output.Parse()
+	return
+}

--- a/vendor/github.com/cloudfoundry-community/vaultkv/mount.go
+++ b/vendor/github.com/cloudfoundry-community/vaultkv/mount.go
@@ -1,0 +1,199 @@
+package vaultkv
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	//MountTypeGeneric is what the key value backend was called prior to 0.8.0
+	MountTypeGeneric = "generic"
+	//MountTypeKV is the type string to get a Key Value backend
+	MountTypeKV = "kv"
+)
+
+//Mount represents a backend mounted at a point in Vault.
+type Mount struct {
+	//The type of mount at this point
+	Type        string
+	Description string
+	Config      *MountConfig
+	Options     map[string]interface{}
+}
+
+//MountConfig specifies configuration options given when initializing a backend.
+type MountConfig struct {
+	DefaultLeaseTTL time.Duration
+	MaxLeaseTTL     time.Duration
+	PluginName      string
+	ForceNoCache    bool
+}
+
+type mountListAPI struct {
+	Type        string                 `json:"type"`
+	Description string                 `json:"description"`
+	Config      mountConfigListAPI     `json:"config"`
+	Options     map[string]interface{} `json:"options"`
+}
+
+func (m mountListAPI) Parse() Mount {
+	return Mount{
+		Type:        m.Type,
+		Description: m.Description,
+		Config:      m.Config.Parse(),
+		Options:     m.Options,
+	}
+}
+
+type mountConfigListAPI struct {
+	//time in seconds
+	DefaultLeaseTTL int    `json:"default_lease_ttl"`
+	MaxLeaseTTL     int    `json:"max_lease_ttl"`
+	PluginName      string `json:"plugin_name"`
+	ForceNoCache    bool   `json:"force_no_cache"`
+}
+
+func (m mountConfigListAPI) Parse() *MountConfig {
+	return &MountConfig{
+		DefaultLeaseTTL: time.Duration(m.DefaultLeaseTTL) * time.Second,
+		MaxLeaseTTL:     time.Duration(m.MaxLeaseTTL) * time.Second,
+		PluginName:      m.PluginName,
+		ForceNoCache:    m.ForceNoCache,
+	}
+}
+
+type mountConfigEnableAPI struct {
+	DefaultLeaseTTL string `json:"default_lease_ttl,omitempty"`
+	MaxLeaseTTL     string `json:"max_lease_ttl,omitempty"`
+	PluginName      string `json:"plugin_name,omitempty"`
+	ForceNoCache    bool   `json:"force_no_cache,omitempty"`
+}
+
+func newMountConfigEnableAPI(conf *MountConfig) *mountConfigEnableAPI {
+	if conf == nil {
+		return nil
+	}
+
+	return &mountConfigEnableAPI{
+		DefaultLeaseTTL: func() string {
+			if conf.DefaultLeaseTTL == 0 {
+				return ""
+			}
+			return conf.DefaultLeaseTTL.String()
+		}(),
+		MaxLeaseTTL: func() string {
+			if conf.MaxLeaseTTL == 0 {
+				return ""
+			}
+			return conf.DefaultLeaseTTL.String()
+		}(),
+		PluginName:   conf.PluginName,
+		ForceNoCache: conf.ForceNoCache,
+	}
+}
+
+//ListMounts queries the Vault backend for a list of active mounts that can
+// be seen with the current authentication token. It is returned as a map
+// of mount points to mount information.
+func (c *Client) ListMounts() (map[string]Mount, error) {
+	output := map[string]interface{}{}
+	//Prior to 1.10, the mount names were top level keys. Then, they duplicated the
+	// information into "data" with other metadata in the top level keys. So we need
+	// to check if the data key is there (and isn't just a mount name)
+	err := c.doRequest("GET", "/sys/mounts", nil, &output)
+	if err != nil {
+		return nil, err
+	}
+
+	var mounts map[string]mountListAPI
+	if dataKey, ok := output["data"]; ok {
+		mounts = getMountList(dataKey)
+	}
+
+	if mounts == nil {
+		mounts := getMountList(output)
+		if mounts == nil {
+			return nil, fmt.Errorf("Could not parse mount list")
+		}
+	}
+
+	ret := map[string]Mount{}
+	for k, v := range mounts {
+		ret[strings.TrimRight(k, "/")] = v.Parse()
+	}
+
+	return ret, err
+}
+
+func getMountList(candidate interface{}) map[string]mountListAPI {
+	//check if data key is not a mount name
+	b, err := json.Marshal(&candidate)
+	if err != nil {
+		return nil
+	}
+
+	tmpOutput := map[string]mountListAPI{}
+	err = json.Unmarshal(b, &tmpOutput)
+	if err != nil {
+		return nil
+	}
+
+	return tmpOutput
+}
+
+//KVMountOptions is a map[string]interface{} that can be given as the options
+//when mounting a backend. It has Version manipulation functions to make life
+//easier.
+type KVMountOptions map[string]interface{}
+
+//GetVersion retruns the version held in the KVMountOptions object
+func (o KVMountOptions) GetVersion() int {
+	if o == nil {
+		return 1
+	}
+
+	version, hasExplicitVersion := o["version"]
+	if !hasExplicitVersion {
+		return 1
+	}
+
+	vStr := version.(string)
+	ret, _ := strconv.Atoi(vStr)
+	return ret
+}
+
+//WithVersion returns a new KVMountOptions object with the given version
+func (o KVMountOptions) WithVersion(version int) KVMountOptions {
+	if o == nil {
+		o = make(map[string]interface{}, 1)
+	}
+
+	o["version"] = strconv.Itoa(version)
+	return o
+}
+
+//EnableSecretsMount mounts a secrets backend at the given path, configured with
+// the given Mount configuration.
+func (c *Client) EnableSecretsMount(path string, config Mount) error {
+	input := struct {
+		Type        string                `json:"type"`
+		Description string                `json:"description"`
+		Config      *mountConfigEnableAPI `json:"config,omitempty"`
+		Options     interface{}           `json:"options,omitempty"`
+	}{
+		Type:        config.Type,
+		Description: config.Description,
+		Config:      newMountConfigEnableAPI(config.Config),
+		Options:     config.Options,
+	}
+
+	return c.doRequest("POST", fmt.Sprintf("/sys/mounts/%s", path), &input, nil)
+}
+
+//DisableSecretsMount deletes the mount at the given path.
+func (c *Client) DisableSecretsMount(path string) error {
+	return c.doRequest("DELETE", fmt.Sprintf("/sys/mounts/%s", path), nil, nil)
+}

--- a/vendor/github.com/cloudfoundry-community/vaultkv/rekey.go
+++ b/vendor/github.com/cloudfoundry-community/vaultkv/rekey.go
@@ -1,0 +1,228 @@
+package vaultkv
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+)
+
+//Rekey represents a rekey operation currently in progress in the Vault. This
+// wraps an otherwise cumbersome rekey API. Remaining() can be called to see
+// how many keys are still required by the rekey, and then those many keys
+// can be sent through one or more calls to Submit(). This should be created
+// through a call to NewRekey or CurrentRekey. Using an uninitialized Rekey
+// struct will lead to undefined behavior.
+type Rekey struct {
+	client *Client
+	state  RekeyState
+	keys   []string
+}
+
+//RekeyConfig is given to NewRekey to configure the parameters of the rekey
+//operation to be started.
+type RekeyConfig struct {
+	Shares    int      `json:"secret_shares"`
+	Threshold int      `json:"secret_threshold"`
+	PGPKeys   []string `json:"pgp_keys,omitempty"`
+	Backup    bool     `json:"backup,omitempty"`
+}
+
+//RekeyState gives the state of the rekey operation as of the last call to
+//Submit, NewRekey, or CurrentRekey.
+type RekeyState struct {
+	Started          bool   `json:"started"`
+	Nonce            string `json:"nonce"`
+	PendingThreshold int    `json:"t"`
+	PendingShares    int    `json:"n"`
+	//The number of keys given so far in this rekey operation
+	Progress int `json:"progress"`
+	//The total number of keys needed for this rekey operation
+	Required        int      `json:"required"`
+	PGPFingerprints []string `json:"pgp_fingerprints"`
+	Backup          bool     `json:"backup"`
+}
+
+//NewRekey will start a new rekey operation. If successful, a *Rekey is
+//returned containing the necessary state for submitting keys for this rekey
+//operation.
+func (v *Client) NewRekey(conf RekeyConfig) (*Rekey, error) {
+	err := v.rekeyStart(conf)
+	if err != nil {
+		err = v.correct500Error(err)
+		return nil, err
+	}
+
+	return v.CurrentRekey()
+}
+
+//CurrentRekey returns a *Rekey with the state necessary to continue a rekey
+// operation if one is in progress. If no rekey is in progress, *ErrNotFound
+// is returned and no *Rekey is returned.
+func (v *Client) CurrentRekey() (*Rekey, error) {
+	var state RekeyState
+	err := v.doSysRequest("GET", "/sys/rekey/init", nil, &state)
+	if err != nil {
+		err = v.correct500Error(err)
+		return nil, err
+	}
+
+	if !state.Started {
+		return nil, &ErrNotFound{message: "No rekey in progress"}
+	}
+
+	return &Rekey{
+		client: v,
+		state:  state,
+	}, nil
+}
+
+//This is here because in Vault 0.10.3, a regression was introduced that causes
+// rekey operations against an uninitialized or sealed Vault to return a 500
+// instead of a 503
+func (v *Client) correct500Error(err error) error {
+	//Thanks, Vault 0.10.3
+	if _, is500 := err.(*ErrInternalServer); is500 {
+		tmpErr := v.Health(true)
+		if _, isUninitialized := tmpErr.(*ErrUninitialized); isUninitialized {
+			err = tmpErr
+		} else if _, isSealed := tmpErr.(*ErrSealed); isSealed {
+			err = tmpErr
+		}
+	}
+
+	return err
+}
+
+func (v *Client) rekeyStart(conf RekeyConfig) error {
+	return v.doSysRequest("PUT", "/sys/rekey/init", &conf, nil)
+}
+
+//Cancel tells Vault to forget about the current rekey operation
+func (r *Rekey) Cancel() error {
+	return r.client.RekeyCancel()
+}
+
+//RekeyCancel tells Vault to forget about the current rekey operation
+func (v *Client) RekeyCancel() error {
+	return v.doSysRequest("DELETE", "/sys/rekey/init", nil, nil)
+}
+
+//Before 0.10, it was "no rekey in progress". In 0.10, the word barrier was added
+var rekeyRegexp = regexp.MustCompile("no (barrier )?rekey in progress")
+
+//Submit gives keys to the rekey operation specified by this *Rekey object. Any
+//keys beyond the current required amount are ignored. If the Rekey is
+//successful after all keys have been sent, then done will be returned as true.
+//If the threshold is reached and any of the keys were incorrect, an
+//*ErrBadRequest is returned and done is false. In this case, the rekey is not
+//cancelled, but is instead reset. No error is given for an incorrect key
+//before the threshold is reached. An *ErrBadRequest may also be returned if
+//there is no longer any rekey in progress, but in this case, done will be
+//returned as true. To retrieve the new keys after submitting enough existing
+//keys, call Keys() on the Rekey object.
+func (r *Rekey) Submit(keys ...string) (done bool, err error) {
+	for _, key := range keys {
+		var result interface{}
+		result, err = r.client.rekeySubmit(key, r.state.Nonce)
+		if err != nil {
+			if ebr, is400 := err.(*ErrBadRequest); is400 {
+				r.state.Progress = 0
+				//I really hate error string checking, but there's no good way that doesn't
+				//require another API call (which could, in turn, err, and leave us in a
+				//wrong state). This checks if the rekey operation is no longer in
+				//progress
+				if rekeyRegexp.MatchString(ebr.message) {
+					done = true
+				}
+			}
+
+			return
+		}
+
+		switch v := result.(type) {
+		case *RekeyState:
+			r.state = *v
+		case *rekeyKeys:
+			r.keys = v.Keys
+			r.state = RekeyState{}
+			return true, nil
+
+		default:
+			panic("rekeySubmit gave an unknown type")
+		}
+	}
+
+	return false, nil
+}
+
+type rekeyKeys struct {
+	Keys       []string `json:"keys"`
+	KeysBase64 []string `json:"keys_base64"`
+}
+
+func (v *Client) rekeySubmit(key string, nonce string) (ret interface{}, err error) {
+	if key == "" {
+		err = fmt.Errorf("no key provided")
+		return
+	}
+	if nonce == "" {
+		err = fmt.Errorf("no nonce provided")
+		return
+	}
+
+	tempMap := make(map[string]interface{})
+	err = v.doSysRequest(
+		"PUT",
+		"/sys/rekey/update",
+		&struct {
+			Key   string `json:"key"`
+			Nonce string `json:"nonce"`
+		}{
+			Key:   key,
+			Nonce: nonce,
+		},
+		&tempMap,
+	)
+	if err != nil {
+		return
+	}
+
+	jBytes, err := json.Marshal(&tempMap)
+	if err != nil {
+		return
+	}
+
+	var unmarshalTarget interface{} = &RekeyState{}
+	if _, isComplete := tempMap["complete"]; isComplete {
+		unmarshalTarget = &rekeyKeys{}
+	}
+
+	err = json.Unmarshal(jBytes, &unmarshalTarget)
+	if err != nil {
+		return
+	}
+
+	return unmarshalTarget, err
+}
+
+//Remaining returns the number of keys yet required by this rekey operation.
+//This does not refresh state. If you believe that an external agent may have
+//changed the state of the rekey, get a new rekey object with CurrentRekey, or
+//Submit another key.
+func (r *Rekey) Remaining() int {
+	return r.state.Required - r.state.Progress
+}
+
+//State returns the current state of the rekey operation. This does not refresh
+// state. If you believe that an external agent may have changed the state of
+// the rekey, get a new rekey object with CurrentRekey, or Submit another key.
+func (r *Rekey) State() RekeyState {
+	return r.state
+}
+
+//Keys returns the new keys from this rekey operation if the operation has been
+//successful. The return value is undefined if the rekey operation is not yet
+//successful.
+func (r *Rekey) Keys() []string {
+	return r.keys
+}

--- a/vendor/github.com/cloudfoundry-community/vaultkv/root.go
+++ b/vendor/github.com/cloudfoundry-community/vaultkv/root.go
@@ -1,0 +1,196 @@
+package vaultkv
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+)
+
+//GenerateRoot has functions for generating a new root token. Create this
+//object with NewGenerateRoot(). That function performs the necessary
+//initialization for the process
+type GenerateRoot struct {
+	client *Client
+	otp    []byte
+	//Versions of Vault before 11.2 encode their 16 byte root tokens as base16 uuids
+	// After that... they are encoded as base64 strings
+	shouldNotUUIDify bool
+	state            GenerateRootState
+}
+
+//GenerateRootState contains state information about the GenerateRoot operation
+type GenerateRootState struct {
+	Started  bool   `json:"started"`
+	Nonce    string `json:"nonce"`
+	Progress int    `json:"progress"`
+	Required int    `json:"required"`
+	//Vault versions >= 0.9.x return the value as encoded_token
+	EncodedToken string `json:"encoded_token"`
+	//Vault versions before 0.9.x returned the value as encoded_root_token
+	EncodedRootToken string `json:"encoded_root_token"`
+	//Vault versions before 0.11.2 had the user generate their own 16-byte root token
+	// Versions after that have the API generate it for you (at a length that is
+	// decided by the API).
+	OTP       string `json:"otp"`
+	OTPLength int    `json:"otp_length"`
+	Complete  bool   `json:"complete"`
+}
+
+//NewGenerateRoot initializes and returns a new generate root object.
+func (v *Client) NewGenerateRoot() (*GenerateRoot, error) {
+	ret := GenerateRoot{
+		client: v,
+		otp:    make([]byte, 16),
+	}
+	_, err := rand.Read(ret.otp)
+	if err != nil {
+		return nil, fmt.Errorf("Could not generate random values")
+	}
+
+	base64OTP := make([]byte, base64.StdEncoding.EncodedLen(len(ret.otp)))
+	base64.StdEncoding.Encode(base64OTP, ret.otp)
+
+	err = v.doRequest("PUT", "/sys/generate-root/attempt",
+		map[string]string{"otp": string(base64OTP)}, &ret.state)
+	if err != nil && !IsBadRequest(err) {
+		return nil, err
+	}
+
+	if ret.state.OTPLength != 0 || IsBadRequest(err) {
+		//Then we need to let the API generate the root token
+		err = ret.Cancel()
+		if err != nil {
+			return nil, err
+		}
+
+		//In 0.11.2 and 0.11.3, you can't provide an empty body or else Vault EOFs.
+		// So you have to give an empty string otp to prompt Vault to make an otp
+		// of the proper length for you. This was fixed in 0.11.4.
+		err = v.doRequest("PUT", "/sys/generate-root/attempt",
+			map[string]string{"otp": ""}, &ret.state)
+		if err != nil {
+			return nil, err
+		}
+		ret.otp = []byte(ret.state.OTP)
+		ret.shouldNotUUIDify = true
+	}
+
+	return &ret, nil
+}
+
+var genRootRegexp = regexp.MustCompile("no root generation in progress")
+
+//Submit gives keys to the generate root token operation specified by this
+//*GenerateRoot object. Any keys beyond the current required amount are
+//ignored. If the Rekey is successful after all keys have been sent, then done
+//will be returned as true. If the threshold is reached and any of the keys
+//were incorrect, an *ErrBadRequest is returned and done is false. In this
+//case, the generate root is not cancelled, but is instead reset. No error is
+//given for an incorrect key before the threshold is reached. An *ErrBadRequest
+//may also be returned if there is no longer any generate root token operation
+//in progress, but in this case, done will be returned as true. To retrieve the
+//new keys after submitting enough existing keys, call RootToken() on the
+//GenerateRoot object.
+func (g *GenerateRoot) Submit(keys ...string) (done bool, err error) {
+	for _, key := range keys {
+		g.state, err = g.client.genRootSubmit(key, g.state.Nonce)
+		if err != nil {
+			if ebr, is400 := err.(*ErrBadRequest); is400 {
+				g.state.Progress = 0
+				//I really hate error string checking, but there's no good way that doesn't
+				//require another API call (which could, in turn, err, and leave us in a
+				//wrong state). This checks if the generate root token is no longer in
+				// progress
+				if genRootRegexp.MatchString(ebr.message) {
+					done = true
+				}
+			}
+
+			return
+		}
+
+		if g.state.Complete {
+			break
+		}
+	}
+
+	return g.state.Complete, nil
+}
+
+//Cancel cancels the current generate root operation
+func (g *GenerateRoot) Cancel() error {
+	return g.client.GenerateRootCancel()
+}
+
+//GenerateRootCancel cancels the current generate root operation
+func (v *Client) GenerateRootCancel() error {
+	return v.doSysRequest("DELETE", "/sys/generate-root/attempt", nil, nil)
+}
+
+func (v *Client) genRootSubmit(key string, nonce string) (ret GenerateRootState, err error) {
+	err = v.doSysRequest(
+		"PUT",
+		"/sys/generate-root/update",
+		&struct {
+			Key   string `json:"key"`
+			Nonce string `json:"nonce"`
+		}{
+			Key:   key,
+			Nonce: nonce,
+		},
+		&ret,
+	)
+
+	return
+}
+
+//Remaining returns the number of keys yet required by this generate root token
+//operation. This does not refresh state, and only reflects the last action of
+//this GenerateRoot object.
+func (g *GenerateRoot) Remaining() int {
+	return g.state.Required - g.state.Progress
+}
+
+//State returns the current state of the generate root operation. This does not
+//refresh state, and only reflects the last action of this GenerateRoot object.
+func (g *GenerateRoot) State() GenerateRootState {
+	return g.state
+}
+
+//RootToken returns the new root token from this operation if the operation has
+//been successful. The return value is undefined if the operation is not yet
+//successful.
+func (g *GenerateRoot) RootToken() (string, error) {
+	rawTok := g.state.EncodedToken
+	if rawTok == "" {
+		rawTok = g.state.EncodedRootToken
+	}
+
+	for len(rawTok)%4 != 0 {
+		rawTok += "="
+	}
+
+	tok, err := base64.StdEncoding.DecodeString(rawTok)
+	if err != nil {
+		return "", fmt.Errorf("Could not decode base64 token: %s", err)
+	}
+
+	if len(tok) != len(g.otp) {
+		return "", fmt.Errorf("token length / one-time password length mismatch (%d/%d)", len(tok), len(g.otp))
+	}
+	for i := 0; i < len(g.otp); i++ {
+		tok[i] ^= g.otp[i]
+	}
+
+	ret := string(tok)
+	if !g.shouldNotUUIDify {
+		tokHex := make([]byte, hex.EncodedLen(len(tok)))
+		hex.Encode(tokHex, tok)
+		ret = fmt.Sprintf("%s-%s-%s-%s-%s",
+			tokHex[0:8], tokHex[8:12], tokHex[12:16], tokHex[16:20], tokHex[20:])
+	}
+
+	return ret, nil
+}

--- a/vendor/github.com/cloudfoundry-community/vaultkv/sys.go
+++ b/vendor/github.com/cloudfoundry-community/vaultkv/sys.go
@@ -1,0 +1,241 @@
+package vaultkv
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+func (v *Client) doSysRequest(
+	method, path string,
+	input interface{},
+	output interface{}) error {
+	err := v.doRequest(method, path, input, output)
+	//In sys contexts, 400 can mean that the Vault is uninitialized.
+	if _, is400 := err.(*ErrBadRequest); is400 {
+		initialized, initErr := v.IsInitialized()
+		if initErr != nil {
+			return initErr
+		}
+
+		if !initialized {
+			return &ErrUninitialized{message: "Your Vault is not initialized"}
+		}
+	}
+
+	return err
+}
+
+//IsInitialized returns true if the targeted Vault is initialized
+func (v *Client) IsInitialized() (is bool, err error) {
+	//Don't call doSysRequest from here because it calls IsInitialized
+	// and that could get ugly
+	err = v.doRequest(
+		"GET",
+		"/sys/init",
+		nil,
+		&struct {
+			Initialized *bool `json:"initialized"`
+		}{
+			Initialized: &is,
+		})
+
+	return
+}
+
+//SealState is the return value from Unseal and SealStatus. Type is only
+//populated by SealStatus. ClusterName and ClusterID are only populated is
+//Vault is unsealed.
+type SealState struct {
+	//Type is the type of unseal key. It is not returned from Unseal
+	Type   string `json:"type,omitempty"`
+	Sealed bool   `json:"sealed"`
+	//Threshold is the number of keys required to reconstruct the master key
+	Threshold int `json:"t"`
+	//NumShares is the number of keys the master key has been split into
+	NumShares int `json:"n"`
+	//Progress is the number of keys that have been provided in the current unseal attempt
+	Progress int    `json:"progress"`
+	Nonce    string `json:"nonce"`
+	Version  string `json:"version"`
+	//ClusterName is only returned from an unsealed Vault.
+	ClusterName string `json:"cluster_name,omitempty"`
+	//ClusterID is only returned from an unsealed Vault.
+	ClusterID string `json:"cluster_id,omitempty"`
+}
+
+//SealStatus calls the /sys/seal-status endpoint and returns the info therein
+func (v *Client) SealStatus() (ret *SealState, err error) {
+	err = v.doSysRequest(
+		"GET",
+		"/sys/seal-status",
+		nil,
+		&ret)
+
+	return
+}
+
+//InitConfig is the information passed to InitVault to configure the Vault.
+//Shares and Threshold are required.
+type InitConfig struct {
+	//Split the master key into this many shares
+	Shares int `json:"secret_shares"`
+	//This many shares are required to reconstruct the master key
+	Threshold       int      `json:"secret_threshold"`
+	RootTokenPGPKey string   `json:"root_token_pgp_key"`
+	PGPKeys         []string `json:"pgp_keys"`
+}
+
+//InitVaultOutput is the return value of InitVault, and contains the generated
+//Keys and RootToken.
+type InitVaultOutput struct {
+	client     *Client
+	Keys       []string `json:"keys"`
+	KeysBase64 []string `json:"keys_base64"`
+	RootToken  string   `json:"root_token"`
+}
+
+//Unseal takes the keys in the InitVaultOutput object and sends each one to the
+//unseal endpoint. If any of the unseal calls are unsuccessful, an error is
+//returned.
+func (i *InitVaultOutput) Unseal() error {
+	for _, key := range i.Keys {
+		sealState, err := i.client.Unseal(key)
+		if err != nil {
+			return err
+		}
+
+		if !sealState.Sealed {
+			break
+		}
+	}
+
+	return nil
+}
+
+//InitVault puts to the /sys/init endpoint to initialize the Vault, and returns
+// the root token and unseal keys that were generated. The token of the client
+// object is automatically set to the root token if the init is successful.
+//If the vault has already been initialized, this returns *ErrBadRequest
+func (v *Client) InitVault(in InitConfig) (out *InitVaultOutput, err error) {
+	out = &InitVaultOutput{}
+	err = v.doSysRequest(
+		"PUT",
+		"/sys/init",
+		&in,
+		&out,
+	)
+
+	if err == nil {
+		v.AuthToken = out.RootToken
+	}
+
+	out.client = v
+
+	return
+}
+
+//Seal puts to the /sys/seal endpoint to seal the Vault.
+// If the Vault is already sealed, this doesn't return an error.
+// If the Vault is unsealed and an incorrect token is provided, then this
+// returns *ErrForbidden. Newer versions of Vault (0.11.2+) APIs return errors
+// if the Vault is uninitialized or already sealed. This function squelches
+// these errors for consistency with earlier versions of Vault
+func (v *Client) Seal() error {
+	err := v.doSysRequest("PUT", "/sys/seal", nil, nil)
+	if err != nil && (IsUninitialized(err) || IsSealed(err)) {
+		err = nil
+	}
+
+	return err
+}
+
+//Unseal puts to the /sys/unseal endpoint with a single key to progress the
+//unseal attempt. If the unseal was successful, then the Sealed member of the
+//returned struct will be false. If the given unseal key is improperly
+//formatted, an *ErrBadRequest is returned. If the vault is already unsealed,
+//no error is returned
+func (v *Client) Unseal(key string) (out *SealState, err error) {
+	out = &SealState{}
+	err = v.doSysRequest(
+		"PUT",
+		"/sys/unseal",
+		&struct {
+			Key string `json:"key"`
+		}{
+			Key: key,
+		},
+		&out,
+	)
+
+	return
+}
+
+//ResetUnseal resets the current unseal attempt, such that the progress towards
+//an unseal becomes 0. If the vault is unsealed, nothing happens and no error
+//is returned.
+func (v *Client) ResetUnseal() (err error) {
+	err = v.doSysRequest(
+		"PUT",
+		"/sys/unseal",
+		&struct {
+			Reset bool `json:"reset"`
+		}{
+			Reset: true,
+		},
+		nil,
+	)
+
+	return
+}
+
+//Health gives information about the current state of the Vault. If standbyok
+//is set to true, no error will be returned in the case that the targeted vault
+//is a standby node. If the targeted node is a standby and standbyok is false,
+//then ErrStandby will be returned. If the Vault is not yet initialized,
+//ErrUninitialized will be returned. If the Vault is initialized but sealed,
+//then ErrSealed will be returned. If none of these are the case, no error is
+//returned.
+func (v *Client) Health(standbyok bool) error {
+	//Don't call doRequest from Health because ParseError calls Health
+	query := url.Values{}
+	boolStr := "false"
+	if standbyok == true {
+		boolStr = "true"
+	}
+	query.Add("standbyok", boolStr)
+	u := *v.VaultURL
+	u.Path = "/v1/sys/health"
+	u.RawQuery = query.Encode()
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add("X-Vault-Token", v.AuthToken)
+	resp, err := v.Client.Do(req)
+	if err != nil {
+		return &ErrTransport{message: err.Error()}
+	}
+
+	errorsStruct := apiError{}
+	json.NewDecoder(resp.Body).Decode(&errorsStruct)
+	errorMessage := strings.Join(errorsStruct.Errors, "\n")
+
+	switch resp.StatusCode {
+	case 200:
+		err = nil
+	case 429:
+		err = &ErrStandby{message: errorMessage}
+	case 501:
+		err = &ErrUninitialized{message: errorMessage}
+	case 503:
+		err = &ErrSealed{message: errorMessage}
+	default:
+		err = errors.New(errorMessage)
+	}
+
+	return err
+}

--- a/vendor/github.com/cloudfoundry-community/vaultkv/test
+++ b/vendor/github.com/cloudfoundry-community/vaultkv/test
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+vaultVersions=(
+"0.9.6"
+"0.10.4"
+"0.11.6"
+"1.0.3"
+"1.1.1"
+)
+
+if [[ $1 == "latest" ]]; then
+  vaultVersions=("${vaultVersions[${#vaultVersions[@]} - 1]}")
+fi
+
+for version in "${vaultVersions[@]}"; do
+  ginkgo -noisySkippings=false -p -cover -coverprofile "vaultkv${version}.coverprofile" -- -v="$version"
+done


### PR DESCRIPTION
Uses the vaultkv library (used in safe) to automagically detect the KV
backend version and handle it seamlessly. It can even use a v1 and v2
backend in the same run! No more needing to give an environment
variable. This also fixes bugs where the vault mount had a slash in it.
Also, the old way was breaking most of the time because Safe doesn't
actually write an api_version key to .svtoken, and spruce was checking
for it.