### PR TITLE
Add (( base64 )) operator

### DIFF
--- a/doc/operators.md
+++ b/doc/operators.md
@@ -19,6 +19,7 @@
 - [vault](#-vault-)
 - [awsparam](#-awsparam-)
 - [awssecret](#-awssecret-)
+- [base64](#-base64-)
 
 Additionally, there are operatiors that are specific to merging arrays. For more detail
 see the [array merging documentation][array-merging]:
@@ -351,6 +352,17 @@ You may combine these additional arguments with `&`; for example `secret/name?ke
 
 [Example][awssecret-example]
 
+## (( base64 ))
+
+Usage: `(( base64 LITERAL|REFERENCE ... ))`
+
+When working with configs that require lots of base64 encoding, it can be quite
+tedious to manually encode and decode the values when trying to inspect or
+update the existing configuration. The `((base64))` operator allows for merge
+time base64 encoding of string literals specified directly, or by reference.
+
+[Example][base64-example]
+
 [array-merging]:      https://github.com/geofffranks/spruce/blob/master/doc/array-merging.md
 [env-var]:            https://github.com/geofffranks/spruce/blob/master/doc/environment-variables-and-defaults.md
 [vault]:              https://vaultproject.io
@@ -374,3 +386,4 @@ You may combine these additional arguments with `&`; for example `secret/name?ke
 [ips-example]:        https://spruce.cf/#568526af82aec5448ddf34740dbd70a3
 [awsparam-example]:   values-from-aws-parameter-store.md
 [awssecret-example]:  values-from-aws-secrets-manager.md
+[base64-example]:     https://spruce.cf/#0aa8626b70fd5757fd148d7da4ffec37?update/with/new/version/when/released

--- a/op_base64.go
+++ b/op_base64.go
@@ -1,0 +1,96 @@
+package spruce
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/starkandwayne/goutils/ansi"
+
+	"github.com/starkandwayne/goutils/tree"
+
+	. "github.com/geofffranks/spruce/log"
+)
+
+// Base64Operator ...
+type Base64Operator struct{}
+
+// Setup ...
+func (Base64Operator) Setup() error {
+	return nil
+}
+
+// Phase ...
+func (Base64Operator) Phase() OperatorPhase {
+	return EvalPhase
+}
+
+// Dependencies ...
+func (Base64Operator) Dependencies(_ *Evaluator, _ []*Expr, _ []*tree.Cursor, auto []*tree.Cursor) []*tree.Cursor {
+	return auto
+}
+
+// Run ...
+func (Base64Operator) Run(ev *Evaluator, args []*Expr) (*Response, error) {
+	DEBUG("running (( base64 ... )) operation at $.%s", ev.Here)
+	defer DEBUG("done with (( base64 ... )) operation at $%s\n", ev.Here)
+
+	if len(args) != 1 {
+		return nil, fmt.Errorf("base64 operator requires exactly one string or reference argument")
+	}
+
+	var contents string
+
+	arg := args[0]
+	i := 0
+	v, err := arg.Resolve(ev.Tree)
+	if err != nil {
+		DEBUG("  arg[%d]: failed to resolve expression to a concrete value", i)
+		DEBUG("     [%d]: error was: %s", i, err)
+		return nil, err
+	}
+
+	switch v.Type {
+	case Literal:
+		DEBUG("  arg[%d]: using string literal '%v'", i, v.Literal)
+		DEBUG("     [%d]: appending '%v' to resultant string", i, v.Literal)
+		if fmt.Sprintf("%T", v.Literal) != "string" {
+			return nil, ansi.Errorf("@R{tried to base64 encode} @c{%v}@R{, which is not a string scalar}", v.Literal)
+		}
+		contents = fmt.Sprintf("%v", v.Literal)
+
+	case Reference:
+		DEBUG("  arg[%d]: trying to resolve reference $.%s", i, v.Reference)
+		s, err := v.Reference.Resolve(ev.Tree)
+		if err != nil {
+			DEBUG("     [%d]: resolution failed\n    error: %s", i, err)
+			return nil, fmt.Errorf("Unable to resolve `%s`: %s", v.Reference, err)
+		}
+
+		switch s.(type) {
+		case string:
+			DEBUG("     [%d]: appending '%s' to resultant string", i, s)
+			contents = fmt.Sprintf("%v", s)
+
+		default:
+			DEBUG("  arg[%d]: %v is not a string scalar", i, s)
+			return nil, ansi.Errorf("@R{tried to base64 encode} @c{%v}@R{, which is not a string scalar}", v.Reference)
+		}
+
+	default:
+		DEBUG("  arg[%d]: I don't know what to do with '%v'", i, arg)
+		return nil, fmt.Errorf("base64 operator only accepts string literals and key reference argument")
+	}
+	DEBUG("")
+
+	encoded := base64.StdEncoding.EncodeToString([]byte(contents))
+	DEBUG("  resolved (( base64 ... )) operation to the string:\n    \"%s\"", string(encoded))
+
+	return &Response{
+		Type:  Replace,
+		Value: string(encoded),
+	}, nil
+}
+
+func init() {
+	RegisterOp("base64", Base64Operator{})
+}

--- a/operator_test.go
+++ b/operator_test.go
@@ -1901,6 +1901,57 @@ meta:
 		})
 	})
 
+	Convey("Base64 Operator", t, func() {
+		op := Base64Operator{}
+		ev := &Evaluator{
+			Tree: YAML(
+				`meta:
+  sample: "Sample Text To Base64 Encode From Reference"
+`),
+		}
+
+		Convey("can encode a string literal", func() {
+			r, err := op.Run(ev, []*Expr{
+				str("Sample Text To Base64 Encode"),
+			})
+			So(err, ShouldBeNil)
+			So(r, ShouldNotBeNil)
+
+			So(r.Type, ShouldEqual, Replace)
+			So(r.Value.(string), ShouldEqual, "U2FtcGxlIFRleHQgVG8gQmFzZTY0IEVuY29kZQ==")
+		})
+
+		Convey("can encode from a reference", func() {
+			r, err := op.Run(ev, []*Expr{
+				ref("meta.sample"),
+			})
+
+			So(err, ShouldBeNil)
+			So(r, ShouldNotBeNil)
+
+			So(r.Type, ShouldEqual, Replace)
+
+			So(r.Value.(string), ShouldEqual, "U2FtcGxlIFRleHQgVG8gQmFzZTY0IEVuY29kZSBGcm9tIFJlZmVyZW5jZQ==")
+		})
+
+		Convey("can handle non string scalar input", func() {
+			r, err := op.Run(ev, []*Expr{
+				str("one"), num(1),
+			})
+			So(err, ShouldNotBeNil)
+			So(r, ShouldBeNil)
+		})
+
+		Convey("can handle non string scalar input (i.e numbers)", func() {
+			r, err := op.Run(ev, []*Expr{
+				num(1),
+			})
+			So(err, ShouldNotBeNil)
+			So(r, ShouldBeNil)
+		})
+
+	})
+
 	Convey("awsparam/awssecret operator", t, func() {
 		op := AwsOperator{variant: "awsparam"}
 		ev := &Evaluator{


### PR DESCRIPTION
Looking to add a `(( base64 ))` operator to spruce to assist with maintaining lots of configs that require base64 encoding. This allows for translating from plain-text for readability and ease of config management at merge time.

Basic usage looks like:
```yaml
meta:
  plain: "Here is a string to be encoded by referencing meta.plain"

encoded: (( base64 meta.plain ))
encoded_direcctly: (( base64 "This is text that will be encoded directly" ))
```
