### PR TITLE
Avoid parsing STDIN twice if "-" provided

### DIFF
--- a/cmd/spruce/main.go
+++ b/cmd/spruce/main.go
@@ -285,16 +285,18 @@ func splitLoadYamlFile(file string) ([]YamlFile, error) {
 
 func cmdMergeEval(options mergeOpts) (map[interface{}]interface{}, error) {
 	files := []YamlFile{}
-	stdinInfo, err := os.Stdin.Stat()
-	if err != nil {
-		return nil, ansi.Errorf("@R{Error statting STDIN} - Bailing out: %s\n", err.Error())
-	}
-	if stdinInfo.Mode()&os.ModeCharDevice == 0 {
-		options.Files = append(options.Files, "-")
-	}
 
 	if len(options.Files) < 1 {
-		return nil, ansi.Errorf("@R{Error reading STDIN}: no data found. Did you forget to pipe data to STDIN, or specify yaml files to merge?")
+		stdinInfo, err := os.Stdin.Stat()
+		if err != nil {
+			return nil, ansi.Errorf("@R{Error statting STDIN} - Bailing out: %s\n", err.Error())
+		}
+
+		if stdinInfo.Mode()&os.ModeCharDevice != 0 {
+			return nil, ansi.Errorf("@R{Error reading STDIN}: no data found. Did you forget to pipe data to STDIN, or specify yaml files to merge?")
+		}
+
+		options.Files = append(options.Files, "-")
 	}
 
 	for _, file := range options.Files {


### PR DESCRIPTION
In the case that the user provides "-" literally as a "filename" to
merge, spruce will currently try to load STDIN twice. The second attempt
will fail, telling you that STDIN is empty because it was emptied from
the first parse.

This was because the existing code adds "-" as a filename to load as
long as there is any input to STDIN. Therefore, "-" would be in the list
twice. Now, it will only do this if there were no files defined
explicitly by the user.

The behavior that led to this bug did add the feature that if there was
input in STDIN as well as filenames explicitly given by the user, spruce
would use both. However, given that the order of where stdin would be
merged in the stream was not documented (effectively, it would be merged
last), and versions of spruce before 24.0.0 did not exhibit this
behavior, I made the decision to revert to the previous behavior of not
auto-adding STDIN if files are explicitly specified.

Closes #311 