### PR TITLE
[fix issue #256] handle empty YAML files

### DIFF
--- a/cmd/spruce/main.go
+++ b/cmd/spruce/main.go
@@ -224,11 +224,18 @@ func parseGoPatch(data []byte) (patch.Ops, error) {
 	}
 	return ops, nil
 }
+
 func parseYAML(data []byte) (map[interface{}]interface{}, error) {
 	y, err := simpleyaml.NewYaml(data)
 	if err != nil {
 		return nil, err
 	}
+
+	if empty_y, _ :=  simpleyaml.NewYaml([]byte{}); *y == *empty_y {
+		DEBUG("YAML doc is empty, creating empty hash/map")
+		return make(map[interface{}]interface{}), nil
+	}
+
 	doc, err := y.Map()
 
 	if err != nil {

--- a/cmd/spruce/main_test.go
+++ b/cmd/spruce/main_test.go
@@ -42,13 +42,12 @@ asdf: fdsa
 			So(err.Error(), ShouldContainSubstring, "unmarshal []byte to yaml failed:")
 			So(obj, ShouldBeNil)
 		})
-		Convey("returns error if yaml is empty", func() {
+		Convey("does not return error if yaml is empty", func() {
 			data := `---
 `
 			obj, err := parseYAML([]byte(data))
-			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldContainSubstring, "Root of YAML document is not a hash/map:")
-			So(obj, ShouldBeNil)
+			So(err, ShouldBeNil)
+			So(obj, ShouldNotBeNil)
 		})
 		Convey("returns error if yaml is a bool", func() {
 			data := `


### PR DESCRIPTION
If the YAML file is [effectively] empty (i.e. does not contain the root hash/map), create an empty hash/map and display a message in debug instead of exiting with error. Fixes #256