### PR TITLE
[fixes issue #316] display build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ to audit what credentials your configs are retrieving for a system..
 
 Licensed under [the MIT License][license]
 
-[build-status-icon]:    https://ci.starkandwayne.com/api/v1/teams/main/pipelines/spruce-release/jobs/test/badge
-[build-status-link]:    https://ci.starkandwayne.com/teams/main/pipelines/spruce-release
+[build-status-icon]:    https://ci.spruce.cf/api/v1/teams/main/pipelines/spruce-release/jobs/test/badge
+[build-status-link]:    https://ci.spruce.cf/teams/main/pipelines/spruce-release
 [slack-channel]:        https://cloudfoundry.slack.com/messages/spruce/
 [slack-badge]:          http://slack.cloudfoundry.org/badge.svg
 [dry-definition]:       https://en.wikipedia.org/wiki/Don%27t_repeat_yourself


### PR DESCRIPTION
Update CI URL to https://ci.spruce.cf to display build status in README.md
Fixes issue #316 