### PR TITLE
Add trusted ca-certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,11 @@ RUN cd /go/src/github.com/geofffranks/spruce && \
        -ldflags "-s -w -extldflags '-static' -X main.Version=$( (git describe --tags 2>/dev/null || (git rev-parse HEAD | cut -c-8)) | sed 's/^v//' )" \
        cmd/spruce/main.go
 
+FROM alpine:latest AS certificates
+RUN apk add --no-cache ca-certificates
+
 FROM scratch
 COPY --from=build /usr/bin/spruce /spruce
+COPY --from=certificates /etc/ssl/ /etc/ssl/
 ENV PATH=/
 CMD ["/spruce"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:alpine as build
+FROM golang:1.13-alpine AS go
+
+FROM go AS build
 RUN apk --no-cache add git
 COPY . /go/src/github.com/geofffranks/spruce
 RUN cd /go/src/github.com/geofffranks/spruce && \


### PR DESCRIPTION
When using https, spruce needs a list of trusted CA certificates.

This provides the trusted certs from the latest alpine image.

Hopefully, this will cause less people to disable SSL verification (a bad
   practice).

I also had to force docker image to build with Go 1.13

It wasn't building with the latest version of the golang:alpine docker image.