### PR TITLE
New `(( shuffle ... ))` operator

### DIFF
--- a/doc/operators.md
+++ b/doc/operators.md
@@ -14,6 +14,7 @@
 - [load](#-load-)
 - [param](#-param-)
 - [prune](#-prune-)
+- [shuffle](#-shuffle-)
 - [sort](#-sort-)
 - [static_ips](#-static_ips-)
 - [vault](#-vault-)
@@ -265,6 +266,15 @@ actual name, e.g. `10.local: (( prune ))` will **not** work. You have to use the
 go-patch equivalent instruction instead.
 
 [Example][prune-example]
+
+## (( shuffle ))
+
+Usage: `(( shuffle LITERAL | REFERENCE [other [args]] ))`
+
+This operator flattens all of its arguments once, into a single
+list, and then shuffles them randomly.  This is useful for
+switching the order of availability zones for a first
+approximation for AZ load balancing.
 
 ## (( sort ))
 

--- a/op_shuffle.go
+++ b/op_shuffle.go
@@ -1,0 +1,93 @@
+package spruce
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/starkandwayne/goutils/tree"
+
+	. "github.com/geofffranks/spruce/log"
+)
+
+// ShuffleOperator ...
+type ShuffleOperator struct{}
+
+// Setup ...
+func (ShuffleOperator) Setup() error {
+	return nil
+}
+
+// Phase ...
+func (ShuffleOperator) Phase() OperatorPhase {
+	return EvalPhase
+}
+
+// Dependencies ...
+func (ShuffleOperator) Dependencies(_ *Evaluator, _ []*Expr, _ []*tree.Cursor, auto []*tree.Cursor) []*tree.Cursor {
+	return auto
+}
+
+// Run ...
+func (ShuffleOperator) Run(ev *Evaluator, args []*Expr) (*Response, error) {
+	DEBUG("running (( shuffle ... )) operation at $.%s", ev.Here)
+	defer DEBUG("done with (( shuffle ... )) operation at $%s\n", ev.Here)
+
+	var vals []interface{}
+
+	for i, arg := range args {
+		v, err := arg.Resolve(ev.Tree)
+		if err != nil {
+			DEBUG("     [%d]: resolution failed\n    error: %s", i, err)
+			return nil, err
+		}
+
+		switch v.Type {
+		case Literal:
+			DEBUG("  arg[%d]: found string literal '%s'", i, v.Literal)
+			vals = append(vals, v.Literal)
+
+		case Reference:
+			DEBUG("  arg[%d]: trying to resolve reference $.%s", i, v.Reference)
+			s, err := v.Reference.Resolve(ev.Tree)
+			if err != nil {
+				DEBUG("     [%d]: resolution failed\n    error: %s", i, err)
+				return nil, fmt.Errorf("Unable to resolve `%s`: %s", v.Reference, err)
+			}
+
+			switch s.(type) {
+			case []interface{}:
+				for _, thing := range s.([]interface{}) {
+					vals = append(vals, thing)
+				}
+
+			case map[interface{}]interface{}:
+				DEBUG("     [%d]: resolved to a map; error!", i)
+				return nil, fmt.Errorf("shuffle only accepts arrays and string values")
+
+			default:
+				vals = append(vals, s.(interface{}))
+			}
+
+		default:
+			DEBUG("  arg[%d]: I don't know what to do with '%v'", i, arg)
+			return nil, fmt.Errorf("shuffle operator only accepts key reference arguments")
+		}
+		DEBUG("")
+	}
+
+	return &Response{
+		Type:  Replace,
+		Value: shuffle(vals),
+	}, nil
+}
+
+func init() {
+	RegisterOp("shuffle", ShuffleOperator{})
+}
+
+func shuffle(l []interface{}) []interface{} {
+	rand.Seed(time.Now().UnixNano())
+	rand.Shuffle(len(l), func(i, j int) { l[i], l[j] = l[j], l[i] })
+	return l
+}


### PR DESCRIPTION
This PR introduces a new `(( shuffle ... ))` operator, for randomizing the
ordering of managed lists.  This is not a great idea for workflows that
regularly re-evaluate the input YAML, but for other tools that use Spruce
in purely generative applications, it works great!

We are planning to use this to randomize AZ placement of single-node
service instances.