### PR TITLE
Bump Go version to `1.15`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-- 1.13
+- 1.15
 
 sudo: false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine AS go
+FROM golang:1.15-alpine AS go
 
 FROM go AS build
 RUN apk --no-cache add git

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -23,7 +23,7 @@ meta:
     password: (( param "DockerHub Auth now required to avoid 429s" ))
 
   go:
-    version: 1.13
+    version: 1.15
     module:  (( concat "github.com/" meta.github.owner "/" meta.github.repo ))
     cmd_module: (( grab meta.go.module ))
     binary:  (( grab meta.github.repo ))

--- a/ci/settings.yml
+++ b/ci/settings.yml
@@ -18,7 +18,7 @@ meta:
     password: (( vault "secret/dockerhub/cisprucecf:password" ))
 
   go:
-    version: 1.13
+    version: 1.15
     cmd_module: (( concat meta.go.module "/cmd/spruce" ))
     force_static_binary: true
   github:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/geofffranks/spruce
 
-go 1.14
+go 1.15
 
 require (
 	github.com/Knetic/govaluate v3.0.0+incompatible


### PR DESCRIPTION
There are multiple spots where the Go version is specified and they are
currently not in sync.

Set Go version `1.15` as the new default in Go modules, Travis, and CI.

Run `go mod vendor` and `go mod tidy` to make sure the modules are fine.
