### PR TITLE
Introduce `(( stringify ))` operator

### DIFF
--- a/doc/operators.md
+++ b/doc/operators.md
@@ -17,12 +17,13 @@
 - [shuffle](#-shuffle-)
 - [sort](#-sort-)
 - [static_ips](#-static_ips-)
+- [stringify](#-stringify-)
 - [vault](#-vault-)
 - [awsparam](#-awsparam-)
 - [awssecret](#-awssecret-)
 - [base64](#-base64-)
 
-Additionally, there are operatiors that are specific to merging arrays. For more detail
+Additionally, there are operators that are specific to merging arrays. For more detail
 see the [array merging documentation][array-merging]:
 
 - `(( append ))` - Adds the data to the end of the corresponding array in the root document.
@@ -30,7 +31,7 @@ see the [array merging documentation][array-merging]:
 - `(( insert ))` - Inserts the data before or after a specified index, or object.
 - `(( merge ))` - Merges the data on top of an existing array based on a common key. This
   requires each element to be an object, all with the common key used for merging.
-- `(( inline ))` - Merges the data ontop of an existing array, based on the indices of the
+- `(( inline ))` - Merges the data on top of an existing array, based on the indices of the
   array.
 - `(( replace ))` - Removes the existing array, and replaces it with the new one.
 - `(( delete ))` - Deletes data at a specific index, or objects identified by the value
@@ -58,7 +59,7 @@ for more information on environment variables and the logical-or.
 Usage: `(( calc EXPRESSION ))`
 
 The `(( calc ))` operator allows you to perform mathematical operations inside your YAML.
-You can reference other values in the datastructure, as well as literal numerics. If you
+You can reference other values in the data structure, as well as literal numerics. If you
 have more sophisticated calculations in mind, you can use these built-in functions inside
 your expressions: `max`, `min`, `mod`, `pow`, `sqrt`, `floor`, and `ceil`.
 
@@ -308,6 +309,38 @@ static IPs for the network of a VM, and pull in as many as are needed based on t
 count. It even supports BOSH AZs fairly well.
 
 [Example][static_ips-example]
+
+## (( stringify ))
+
+Usage: `(( stringify REFERENCE ))`
+
+There are use cases, especially with Kubernetes resources like config maps, where one needs to place a piece of a YAML structure as a multiline string. If you happen to have the actual data already in your current file, you can avoid duplicating the content by simply referencing the part of the YAML and the `(( stringify ... ))` operator correctly marshals the data into your tree structure.
+
+**Example:**
+```sh
+$ cat <<EOF >file.yml
+meta:
+  foo:
+    list:
+    - one
+    - two
+    test:
+      enabled: true
+      one: 2
+
+result: (( stringify meta ))
+EOF
+
+$ spruce merge --prune meta file.yml
+result: |
+  foo:
+    list:
+    - one
+    - two
+    test:
+      enabled: true
+      one: 2
+```
 
 ## (( ips ))
 

--- a/op_stringify.go
+++ b/op_stringify.go
@@ -1,0 +1,75 @@
+package spruce
+
+import (
+	"github.com/geofffranks/spruce/log"
+	"github.com/geofffranks/yaml"
+	fmt "github.com/starkandwayne/goutils/ansi"
+	"github.com/starkandwayne/goutils/tree"
+)
+
+// StringifyOperator ...
+type StringifyOperator struct{}
+
+// Setup ...
+func (StringifyOperator) Setup() error {
+	return nil
+}
+
+// Phase ...
+func (StringifyOperator) Phase() OperatorPhase {
+	return EvalPhase
+}
+
+// Dependencies ...
+func (StringifyOperator) Dependencies(_ *Evaluator, _ []*Expr, _ []*tree.Cursor, auto []*tree.Cursor) []*tree.Cursor {
+	return auto
+}
+
+// Run ...
+func (StringifyOperator) Run(ev *Evaluator, args []*Expr) (*Response, error) {
+	log.DEBUG("running (( stringify ... )) operation at $.%s", ev.Here)
+	defer log.DEBUG("done with (( stringify ... )) operation at $%s\n", ev.Here)
+
+	if len(args) != 1 {
+		return nil, fmt.Errorf("stringify operator requires exactly one reference argument")
+	}
+
+	var arg = args[0]
+	var val interface{}
+	v, err := arg.Resolve(ev.Tree)
+	if err != nil {
+		log.DEBUG(" resolution failed\n error: %s", err)
+		return nil, err
+	}
+
+	switch v.Type {
+	case Reference:
+		log.DEBUG(" trying to resolve reference $.%s", v.Reference)
+		s, err := v.Reference.Resolve(ev.Tree)
+		if err != nil {
+			log.DEBUG(" resolution failed\n error: %s", err)
+			return nil, fmt.Errorf("Unable to resolve `%s`: %s", v.Reference, err)
+		}
+		log.DEBUG("  resolved to a value (could be a map, a list or a scalar)")
+		data, err := yaml.Marshal(s)
+		if err != nil {
+			log.DEBUG("   marshaling failed\n   error: %s", err)
+			return nil, fmt.Errorf("Unable to marshal `%s`: %s", v.Reference, err)
+		}
+		val = string(data)
+
+	default:
+		log.DEBUG(" unsupported expression type, only references are allowed: '%v'", arg)
+		return nil, fmt.Errorf("stringify operator only accepts reference arguments")
+	}
+	log.DEBUG("")
+
+	return &Response{
+		Type:  Replace,
+		Value: val,
+	}, nil
+}
+
+func init() {
+	RegisterOp("stringify", StringifyOperator{})
+}

--- a/operator_test.go
+++ b/operator_test.go
@@ -2123,4 +2123,79 @@ meta:
 			})
 		})
 	})
+
+	Convey("Stringify Operator", t, func() {
+		op := StringifyOperator{}
+		ev := &Evaluator{
+			Tree: YAML(`meta:
+  map:
+    bar: foo
+    foo: bar
+  list:
+  - first
+  - second
+  scalars:
+    bool: true
+    number: 42
+    string: foobar
+`),
+		}
+
+		Convey("cannot use operator with more than one reference", func() {
+			r, err := op.Run(ev, []*Expr{
+				ref("meta.map"),
+				ref("list.0"),
+			})
+			So(err, ShouldNotBeNil)
+			So(r, ShouldBeNil)
+		})
+
+		Convey("cannot use operator with a literal", func() {
+			r, err := op.Run(ev, []*Expr{
+				str("literal"),
+			})
+			So(err, ShouldNotBeNil)
+			So(r, ShouldBeNil)
+		})
+
+		Convey("can stringify map", func() {
+			r, err := op.Run(ev, []*Expr{
+				ref("meta.map"),
+			})
+			So(err, ShouldBeNil)
+			So(r, ShouldNotBeNil)
+
+			So(r.Type, ShouldEqual, Replace)
+			So(r.Value.(string), ShouldEqual, `bar: foo
+foo: bar
+`)
+		})
+
+		Convey("can stringify list", func() {
+			r, err := op.Run(ev, []*Expr{
+				ref("meta.list"),
+			})
+			So(err, ShouldBeNil)
+			So(r, ShouldNotBeNil)
+
+			So(r.Type, ShouldEqual, Replace)
+			So(r.Value.(string), ShouldEqual, `- first
+- second
+`)
+		})
+
+		Convey("can stringify scalars", func() {
+			r, err := op.Run(ev, []*Expr{
+				ref("meta.scalars"),
+			})
+			So(err, ShouldBeNil)
+			So(r, ShouldNotBeNil)
+
+			So(r.Type, ShouldEqual, Replace)
+			So(r.Value.(string), ShouldEqual, `bool: true
+number: 42
+string: foobar
+`)
+		})
+	})
 }


### PR DESCRIPTION
Add new `(( stringify ))` operator to marshal a part of the YAML structure into
a multiline string.

Add section in operator docs to describe the new operator.

Fix minor TYPOs in operator markdown.

Signed-off-by: Matthias Diester <matthias.diester@de.ibm.com>
