### PR TITLE
Add literal support for stringify operator

### DIFF
--- a/doc/operators.md
+++ b/doc/operators.md
@@ -316,31 +316,7 @@ Usage: `(( stringify REFERENCE ))`
 
 There are use cases, especially with Kubernetes resources like config maps, where one needs to place a piece of a YAML structure as a multiline string. If you happen to have the actual data already in your current file, you can avoid duplicating the content by simply referencing the part of the YAML and the `(( stringify ... ))` operator correctly marshals the data into your tree structure.
 
-**Example:**
-```sh
-$ cat <<EOF >file.yml
-meta:
-  foo:
-    list:
-    - one
-    - two
-    test:
-      enabled: true
-      one: 2
-
-result: (( stringify meta ))
-EOF
-
-$ spruce merge --prune meta file.yml
-result: |
-  foo:
-    list:
-    - one
-    - two
-    test:
-      enabled: true
-      one: 2
-```
+[Example][stringify-example]
 
 ## (( ips ))
 
@@ -425,6 +401,7 @@ time base64 encoding of string literals specified directly, or by reference.
 [param-example]:      http://play.spruce.cf/#b7944defbd5d987c70c25fcbae1756a8
 [prune-example]:      http://play.spruce.cf/#ce52f99a0c7470aa2a1e8fd4dddbafff
 [static_ips-example]: http://play.spruce.cf/#ce52f99a0c7470aa2a1e8fd4dddbafff
+[stringify-example]:  https://play.spruce.cf/#f302027e6a6d6f77c04437d18a420db0
 [vault-example]:      https://github.com/geofffranks/spruce/blob/master/doc/pulling-creds-from-vault.md
 [ips-example]:        https://spruce.cf/#568526af82aec5448ddf34740dbd70a3
 [awsparam-example]:   values-from-aws-parameter-store.md

--- a/op_stringify.go
+++ b/op_stringify.go
@@ -43,6 +43,10 @@ func (StringifyOperator) Run(ev *Evaluator, args []*Expr) (*Response, error) {
 	}
 
 	switch v.Type {
+	case Literal:
+		log.DEBUG(" found literal '%s'", v.Literal)
+		val = v.Literal
+
 	case Reference:
 		log.DEBUG(" trying to resolve reference $.%s", v.Reference)
 		s, err := v.Reference.Resolve(ev.Tree)

--- a/operator_test.go
+++ b/operator_test.go
@@ -2150,14 +2150,6 @@ meta:
 			So(r, ShouldBeNil)
 		})
 
-		Convey("cannot use operator with a literal", func() {
-			r, err := op.Run(ev, []*Expr{
-				str("literal"),
-			})
-			So(err, ShouldNotBeNil)
-			So(r, ShouldBeNil)
-		})
-
 		Convey("can stringify map", func() {
 			r, err := op.Run(ev, []*Expr{
 				ref("meta.map"),
@@ -2196,6 +2188,40 @@ foo: bar
 number: 42
 string: foobar
 `)
+		})
+
+		Convey("retain string literal", func() {
+			r, err := op.Run(ev, []*Expr{
+				str("foo"),
+			})
+			So(err, ShouldBeNil)
+			So(r, ShouldNotBeNil)
+
+			So(r.Type, ShouldEqual, Replace)
+			So(r.Value.(string), ShouldEqual, "foo")
+		})
+
+		Convey("retain null literal", func() {
+			r, err := op.Run(ev, []*Expr{
+				null(),
+			})
+			So(err, ShouldBeNil)
+			So(r, ShouldNotBeNil)
+
+			So(r.Type, ShouldEqual, Replace)
+			So(r.Value, ShouldBeNil)
+		})
+
+		Convey("throws errors for dangling references", func() {
+			_, err := op.Run(ev, []*Expr{
+				ref("key.that.does.not.exist"),
+			})
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("throws errors for missing arguments", func() {
+			_, err := op.Run(ev, []*Expr{})
+			So(err, ShouldNotBeNil)
 		})
 	})
 }


### PR DESCRIPTION
Add literal support for stringiy operator to enable '|| nil' expressions

Provide playground example for stringify operator