### PR TITLE
Add dynamic YAML key lookup via bracket notation in grab operator

### DIFF
--- a/doc/operators.md
+++ b/doc/operators.md
@@ -57,6 +57,10 @@ literal values (strings/numbers/booleans), references (paths defining a datastru
 (`||`) to failover to other values. See our notes on [environment variables and default values][env-var]
 for more information on environment variables and the logical-or.
 
+References can also use **dynamic key lookup**: wrap a reference in square brackets
+(e.g. `colors[pick]`) and `spruce` will resolve the inner reference first, then use the
+resulting scalar as the key. See the `(( grab ))` section for an example.
+
 ## (( calc ))
 
 Usage: `(( calc EXPRESSION ))`
@@ -176,6 +180,34 @@ but it's entirely possible to simply `username: (( grab "admin" ))`. I have no i
 might want to do that though, since it's much more typing than `username: admin`...
 
 [Example][grab-example]
+
+**Dynamic key lookup:**
+
+Sometimes the key you want to look up isn't known ahead of time - it lives
+somewhere else in the same document. You can wrap a reference in square brackets
+and `spruce` will resolve that reference first, then use the resulting value as
+the key:
+
+```
+$ cat <<EOF > config.yml
+colors:
+  primary: blue
+  secondary: red
+pick: primary
+chosen: (( grab colors[pick] ))
+EOF
+
+$ spruce merge config.yml
+chosen: blue
+colors:
+  primary: blue
+  secondary: red
+pick: primary
+```
+
+The bracketed reference can itself be a nested path, e.g. `colors[meta.which]`.
+The looked-up value must be a scalar (string, integer, float, or boolean). This
+syntax is available anywhere references are accepted, not just inside `(( grab ))`.
 
 ## (( inject ))
 

--- a/evaluator_test.go
+++ b/evaluator_test.go
@@ -1528,6 +1528,23 @@ output:
 z_one: hello
 z_two: world
 
+#################################### (( join ... )) an array via dynamic bracket reference
+---
+z:
+  greeting: [hello, world]
+lookup: greeting
+output: (( join " " z[lookup] ))
+---
+dataflow:
+- output: (( join " " z[lookup] ))
+---
+lookup: greeting
+output: hello world
+z:
+  greeting:
+  - hello
+  - world
+
 
 ################################################   basic escape sequence handling
 ---

--- a/operator.go
+++ b/operator.go
@@ -3,6 +3,7 @@
 package spruce
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"regexp"
@@ -109,12 +110,13 @@ const (
 
 // Expr ...
 type Expr struct {
-	Type      ExprType
-	Reference *tree.Cursor
-	Literal   interface{}
-	Name      string
-	Left      *Expr
-	Right     *Expr
+	Type           ExprType
+	Reference      *tree.Cursor
+	BracketedNodes []bool
+	Literal        interface{}
+	Name           string
+	Left           *Expr
+	Right          *Expr
 }
 
 func (e *Expr) String() string {
@@ -199,7 +201,20 @@ func (e *Expr) Resolve(tree map[interface{}]interface{}) (*Expr, error) {
 		return &Expr{Type: Literal, Literal: val}, nil
 
 	case Reference:
+		// Clear bracket flags for $VAR nodes before ResolveEnv consumes the "$" sentinel,
+		// so (( grab map[$VAR] )) treats the env-var value as a literal key rather than
+		// as a YAML path to re-resolve against the tree.
+		for i, node := range e.Reference.Nodes {
+			if i < len(e.BracketedNodes) && len(node) > 0 && node[0] == '$' {
+				e.BracketedNodes[i] = false
+			}
+		}
 		e.Reference.Nodes = ResolveEnv(e.Reference.Nodes)
+		nodes, err := ResolveDynamicRefs(e.Reference.Nodes, e.BracketedNodes, tree)
+		if err != nil {
+			return nil, ansi.Errorf("@R{%s}", err)
+		}
+		e.Reference.Nodes = nodes
 		if _, err := e.Reference.Resolve(tree); err != nil {
 			return nil, ansi.Errorf("@R{unable to resolve `}@c{%s}@R{`: %s}", e.Reference, err)
 		}
@@ -224,6 +239,106 @@ func ResolveEnv(nodes []string) []string {
 		}
 	}
 	return resolved
+}
+
+// bracketsOf re-parses a path string to recover which nodes were specified in
+// bracket notation. tree.ParseCursor normalizes both notations into identical
+// Nodes, discarding this distinction, so we must re-derive it from the source.
+func bracketsOf(path string) []bool {
+	var result []bool
+	inBracket := false
+	var buf bytes.Buffer
+
+	push := func(isBracketed bool) {
+		if buf.Len() == 0 {
+			return
+		}
+		// Mirror ParseCursor: skip leading "$" sentinel
+		if len(result) == 0 && buf.String() == "$" {
+			buf.Reset()
+			return
+		}
+		result = append(result, isBracketed)
+		buf.Reset()
+	}
+
+	for _, c := range path {
+		switch c {
+		case '.':
+			if inBracket {
+				buf.WriteRune(c)
+			} else {
+				push(false)
+			}
+		case '[':
+			push(false)
+			inBracket = true
+		case ']':
+			push(true)
+			inBracket = false
+		default:
+			buf.WriteRune(c)
+		}
+	}
+	push(false)
+	return result
+}
+
+// ResolveDynamicRefs resolves nodes that were specified in bracket notation as YAML
+// path references against the tree, enabling (( grab map[key_ref] )) syntax.
+// Mutates bracketed: clears flags for nodes that were substituted, to keep
+// subsequent calls idempotent (e.g. when Dependencies and Run both invoke Resolve).
+func ResolveDynamicRefs(nodes []string, bracketed []bool, t map[interface{}]interface{}) ([]string, error) {
+	hasDynamic := false
+	for _, b := range bracketed {
+		if b {
+			hasDynamic = true
+			break
+		}
+	}
+	if !hasDynamic {
+		return nodes, nil
+	}
+
+	resolved := make([]string, len(nodes))
+	copy(resolved, nodes)
+	for i, node := range nodes {
+		if i >= len(bracketed) || !bracketed[i] {
+			continue
+		}
+		if len(node) == 0 || node[0] == '$' {
+			continue // $VAR nodes were already substituted by ResolveEnv; skip any remnants
+		}
+		if _, err := strconv.ParseUint(node, 10, 64); err == nil {
+			continue // numeric nodes are array indices, not YAML references
+		}
+		c, err := tree.ParseCursor(node)
+		if err != nil {
+			return nil, fmt.Errorf("invalid bracketed key reference %q: %s", node, err)
+		}
+		val, err := c.Resolve(t)
+		if err != nil {
+			return nil, fmt.Errorf("unable to resolve bracketed key reference %q: %s", node, err)
+		}
+		switch v := val.(type) {
+		case string:
+			resolved[i] = v
+		case int:
+			resolved[i] = strconv.Itoa(v)
+		case int64:
+			resolved[i] = strconv.FormatInt(v, 10)
+		case float64:
+			resolved[i] = strconv.FormatFloat(v, 'f', -1, 64)
+		case bool:
+			resolved[i] = strconv.FormatBool(v)
+		default:
+			return nil, fmt.Errorf("bracketed key reference %q resolved to %T; expected a scalar (string, int, float, or bool)", node, val)
+		}
+		// Clear the flag so re-resolving the same Expr (e.g. in JoinOperator.Dependencies
+		// followed by Run) treats the already-substituted node as a literal key.
+		bracketed[i] = false
+	}
+	return resolved, nil
 }
 
 // Evaluate ...
@@ -267,6 +382,20 @@ func (e *Expr) Dependencies(ev *Evaluator, locs []*tree.Cursor) []*tree.Cursor {
 	switch e.Type {
 	case Reference:
 		canonicalize(e.Reference)
+		for i, node := range e.Reference.Nodes {
+			if i >= len(e.BracketedNodes) || !e.BracketedNodes[i] {
+				continue
+			}
+			if len(node) == 0 || node[0] == '$' {
+				continue
+			}
+			if _, err := strconv.ParseUint(node, 10, 64); err == nil {
+				continue
+			}
+			if c, err := tree.ParseCursor(node); err == nil {
+				canonicalize(c)
+			}
+		}
 
 	case LogicalOr:
 		for _, c := range e.Left.Dependencies(ev, locs) {
@@ -454,7 +583,7 @@ func ParseOpcall(phase OperatorPhase, src string) (*Opcall, error) {
 					return args, err
 				}
 				DEBUG("  #%d: parsed as a reference to $.%s", i, c)
-				push(&Expr{Type: Reference, Reference: c})
+				push(&Expr{Type: Reference, Reference: c, BracketedNodes: bracketsOf(arg)})
 			}
 		}
 		pop()

--- a/operator.go
+++ b/operator.go
@@ -309,8 +309,8 @@ func ResolveDynamicRefs(nodes []string, bracketed []bool, t map[interface{}]inte
 		if len(node) == 0 || node[0] == '$' {
 			continue // $VAR nodes were already substituted by ResolveEnv; skip any remnants
 		}
-		if _, err := strconv.ParseUint(node, 10, 64); err == nil {
-			continue // numeric nodes are array indices, not YAML references
+		if _, err := strconv.ParseInt(node, 10, 64); err == nil {
+			continue // numeric nodes (including negatives) are array indices, not YAML references
 		}
 		c, err := tree.ParseCursor(node)
 		if err != nil {
@@ -389,7 +389,7 @@ func (e *Expr) Dependencies(ev *Evaluator, locs []*tree.Cursor) []*tree.Cursor {
 			if len(node) == 0 || node[0] == '$' {
 				continue
 			}
-			if _, err := strconv.ParseUint(node, 10, 64); err == nil {
+			if _, err := strconv.ParseInt(node, 10, 64); err == nil {
 				continue
 			}
 			if c, err := tree.ParseCursor(node); err == nil {

--- a/operator_test.go
+++ b/operator_test.go
@@ -3661,6 +3661,126 @@ line4`)
 			})
 			So(err, ShouldNotBeNil)
 		})
+
+		Convey("can grab a value using a dynamic bracket reference", func() {
+			ev2 := &Evaluator{
+				Tree: YAML(
+					`key:
+  subkey: found it
+  other: value 2
+lookup: subkey
+`),
+			}
+			dynRef := func(s string) *Expr {
+				return &Expr{Type: Reference, Reference: cursor(s), BracketedNodes: bracketsOf(s)}
+			}
+			r, err := op.Run(ev2, []*Expr{
+				dynRef("key[lookup]"),
+			})
+			So(err, ShouldBeNil)
+			So(r, ShouldNotBeNil)
+			So(r.Type, ShouldEqual, Replace)
+			So(r.Value.(string), ShouldEqual, "found it")
+		})
+
+		Convey("can grab a value using a nested path in a bracket reference", func() {
+			ev2 := &Evaluator{
+				Tree: YAML(
+					`key:
+  subkey: found it
+meta:
+  which: subkey
+`),
+			}
+			dynRef := func(s string) *Expr {
+				return &Expr{Type: Reference, Reference: cursor(s), BracketedNodes: bracketsOf(s)}
+			}
+			r, err := op.Run(ev2, []*Expr{
+				dynRef("key[meta.which]"),
+			})
+			So(err, ShouldBeNil)
+			So(r, ShouldNotBeNil)
+			So(r.Type, ShouldEqual, Replace)
+			So(r.Value.(string), ShouldEqual, "found it")
+		})
+
+		Convey("returns error when the bracket key reference resolves to a non-scalar", func() {
+			ev2 := &Evaluator{
+				Tree: YAML(
+					`key:
+  subkey: found it
+lookup:
+  nested: subkey
+`),
+			}
+			dynRef := func(s string) *Expr {
+				return &Expr{Type: Reference, Reference: cursor(s), BracketedNodes: bracketsOf(s)}
+			}
+			_, err := op.Run(ev2, []*Expr{
+				dynRef("key[lookup]"),
+			})
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("can grab a value using a numeric-valued bracket reference", func() {
+			ev2 := &Evaluator{
+				Tree: YAML(
+					`versions:
+  "1": first
+  "2": second
+pick: 2
+`),
+			}
+			dynRef := func(s string) *Expr {
+				return &Expr{Type: Reference, Reference: cursor(s), BracketedNodes: bracketsOf(s)}
+			}
+			r, err := op.Run(ev2, []*Expr{
+				dynRef("versions[pick]"),
+			})
+			So(err, ShouldBeNil)
+			So(r, ShouldNotBeNil)
+			So(r.Type, ShouldEqual, Replace)
+			So(r.Value.(string), ShouldEqual, "second")
+		})
+
+		Convey("can grab a value using an environment variable in a bracket reference", func() {
+			os.Setenv("BRACKET_SUB_KEY", "subkey")
+			ev2 := &Evaluator{
+				Tree: YAML(
+					`key:
+  subkey: found it
+  other: value 2
+`),
+			}
+			dynRef := func(s string) *Expr {
+				return &Expr{Type: Reference, Reference: cursor(s), BracketedNodes: bracketsOf(s)}
+			}
+			r, err := op.Run(ev2, []*Expr{
+				dynRef("key[$BRACKET_SUB_KEY]"),
+			})
+			So(err, ShouldBeNil)
+			So(r, ShouldNotBeNil)
+			So(r.Type, ShouldEqual, Replace)
+			So(r.Value.(string), ShouldEqual, "found it")
+		})
+	})
+
+	Convey("bracketsOf", t, func() {
+		Convey("marks bracket-notation nodes as true", func() {
+			So(bracketsOf("foo[bar]"), ShouldResemble, []bool{false, true})
+		})
+		Convey("marks dot-notation nodes as false", func() {
+			So(bracketsOf("foo.bar"), ShouldResemble, []bool{false, false})
+		})
+		Convey("handles leading $ sentinel", func() {
+			So(bracketsOf("$.foo[bar]"), ShouldResemble, []bool{false, true})
+		})
+		Convey("handles mixed notation", func() {
+			So(bracketsOf("a[b].c[d]"), ShouldResemble, []bool{false, true, false, true})
+		})
+		Convey("handles numeric brackets (array indices)", func() {
+			So(bracketsOf("list[0]"), ShouldResemble, []bool{false, true})
+		})
 	})
 
 	Convey("RawEnv Operator", t, func() {


### PR DESCRIPTION
## Add dynamic YAML key lookup via bracket notation in `grab`

Adds `(( grab map[key_ref] ))` where `key_ref` is a YAML path resolved at evaluation time, analogous to the existing `[$ENVVAR]` bracket syntax. Lets config authors do indirect lookups without duplicating map keys into literals.

```yaml
colors:
  primary: blue
  secondary: red
pick: primary
chosen: (( grab colors[pick] )) # => "blue"
```

The bracketed node can itself be a nested path: `colors[meta.which]`.

### Design

`tree.ParseCursor` normalizes dot and bracket notation into identical `Nodes` slices, which would discard the dot-vs-bracket distinction the feature needs. Rather than forking the upstream parser, the PR:

1. Re-derives which nodes were bracketed by re-scanning the source path (`bracketsOf`), stashing the result on `Expr.BracketedNodes` at parse time.
2. Resolves bracketed nodes as YAML references against the tree (`ResolveDynamicRefs`) just before the cursor resolves, substituting the looked-up value as a literal key in `Reference.Nodes`.
3. Adds the dynamic targets to `Expr.Dependencies` so graph ordering picks them up.

Numeric bracketed nodes (`list[0]`) are left alone — they're array indices, not references. `$VAR` bracketed nodes are handled by the existing `ResolveEnv` path (see fix below).

### Interaction with `$ENVVAR`

`ResolveEnv` strips the `$` sentinel before `ResolveDynamicRefs` runs, so the naive `node[0]=='$'` guard in the dynamic-resolution path is dead code — every `map[$VAR]` would be re-resolved against the tree and fail. The
fix is to clear `BracketedNodes[i]` for `$`-prefixed nodes *before* `ResolveEnv` consumes them, so env-var bracket nodes behave exactly as they did pre-feature.

### Scalar-key handling

`ResolveDynamicRefs` accepts `string`, `int`, `int64`, `float64`, `bool` as bracketed-ref target values. Non-scalars (maps, arrays) return an error with the actual type.

### Public API

No breaking changes. `ResolveEnv` and `tree.Cursor` signatures are untouched. `Expr` gains one new exported field (`BracketedNodes []bool`); callers that construct `Expr{Type: Reference, ...}` directly and never touch
brackets remain source-compatible — the zero value (nil slice) short-circuits all new logic.

### Tests

- Happy path: `key[lookup]`, `key[meta.which]`.
- Env-var regression: `key[$BRACKET_SUB_KEY]`.
- Numeric lookup key: `versions[pick]` where `pick: 2`.
- Non-scalar → error.
- Unit tests for `bracketsOf` (dot, bracket, mixed, `$.` sentinel, numeric).
- Integration test via `evaluator_test.go` exercising `(( join " " z[lookup] ))`.

Fixes #383 