### PR TITLE
chore: bump Go toolchain to go1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/geofffranks/spruce
 
 go 1.26.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/Knetic/govaluate v3.0.0+incompatible


### PR DESCRIPTION
Automated bump of the `toolchain` directive in `go.mod` to go1.26.5. CI will verify.